### PR TITLE
Export the per-clause grammar as esql.GRAMMAR (G1); fix make typecheck

### DIFF
--- a/.claude/status.md
+++ b/.claude/status.md
@@ -59,11 +59,25 @@ that `count` is the only aggregate legal on a non-numeric column (mirroring `_pa
 `grammar.json`, so the pattern exists. It just does not reach far enough, and the gap is silent: a
 clause gaining a rule upstream simply goes unreflected downstream.
 
-- [ ] **G1. Emit the per-clause shapes** alongside the token sets, generated from the parser rather
-  than restated. The consumer then renders a table instead of maintaining a copy. This is the same
-  "token sets are never restated" doctrine, extended from tokens to clause shapes.
+- [x] **G1. Emit the per-clause shapes.** Shipped in v1.5.0 as `esql.GRAMMAR` (`src/esql/grammar.py`):
+  per clause, what it accepts, which operators it takes, what it requires, whether it repeats, plus
+  a slot-kind glossary and the aggregate dtype rule. Plain dicts and lists, so `json.dumps` is the
+  whole export step.
+
+  **Honest about what "generated from the parser" turned out to mean.** The parser is imperative,
+  not a declarative grammar, so there is nothing to mechanically generate from without restructuring
+  it, which the lean ladder does not justify. What ships instead: the token-set dimension *is* single
+  sourced (`WHERE_OPERATORS` / `SUCH_THAT_OPERATORS` / `HAVING_OPERATORS` and
+  `DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS` are constants the parser reads, and `_parse_aggregate` no
+  longer names `count` itself), and every remaining claim is bound to behavior by
+  `tests/parser/test_grammar.py`, which runs the real parser through `validate()` and asserts each
+  listed operator parses in that clause and each unlisted one raises. Verified the guard bites: making
+  `HAVING_OPERATORS` claim CONTAINS fails the test rather than reaching the demo. That kills the
+  silent-drift failure mode, which was the point, without pretending the description is generated.
+
 - [ ] **G2. A guard for the prose.** The clause reference cards are hand-written and only the keyword
-  list is asserted today.
+  list is asserted today. G1 gives the cards something to be checked against: they can now be
+  generated from `GRAMMAR` or asserted to agree with it.
 
 ---
 
@@ -186,7 +200,10 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   `public/docs/syntax.md` section + an ESQL demo example. Pairs with HAS: HAS
   *filters* one grain by another; this *measures* across grains. Design captured now; build parked
   until the datasets/rename plumbing lands.
-- [ ] **mypy clean pass.** 143 errors, all from the dynamic evaluator: union comparisons
+- [ ] **mypy clean pass.** 156 errors (the count was stale at 143 because `make typecheck` called
+  `uv run mypy`, whose console script does not spawn, so the target errored out before reaching
+  mypy; fixed in v1.5.0 to `uv run python -m mypy`, the form every other target uses). All from
+  the dynamic evaluator: union comparisons
   (`[operator]`) and TypedDict key-narrowing (`[typeddict-item]`/`[index]`) mypy can't follow
   through runtime `'group' in aggregate` checks. Options: type the cell/accumulator boundaries as
   `Any` (honest — a `_data_map` slot holds int|float|date or an avg `{'sum','count'}` dict), or
@@ -262,6 +279,17 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   `test_execution_integration.py` that check `HAS` against `IN (SELECT ...)` over `sales.csv`.
   Binding is unchanged from what `CLAUDE.md` commits to: the key set is built from data values and
   membership-tested, with no code or SQL constructed from query text.
+
+## v1.5.0 — the grammar export (2026-07-28)
+
+- [x] **`esql.GRAMMAR` (G1)** and **`make typecheck` fixed.** See the G1 entry above for the export
+  and for what "generated from the parser" honestly amounts to. The gate is green at **142 tests**
+  (was 119).
+
+  `make typecheck` had been calling `uv run mypy`, whose console script fails to spawn, so the
+  target errored before mypy ran and the recorded error count (143) was stale for however long that
+  was true. Now `uv run python -m mypy`, matching every other target, and the real count is 156. The
+  cleanup itself is still open above.
 
 ## 3. Engine-side prep for the ESQL demo
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ format:
 # Advisory: mypy is configured for parity but not yet clean over the dynamic
 # query evaluator (union comparisons, TypedDict key-narrowing). See .claude/status.md.
 typecheck:
-	uv run mypy
+	uv run python -m mypy
 
 build:
 	uv build

--- a/README.md
+++ b/README.md
@@ -128,8 +128,25 @@ parser runs on a lowercased, whitespace-collapsed copy of the query, so offsets 
 back onto what was typed; match it case-insensitively.
 
 The token sets the parser accepts are exported for the same reason: `esql.KEYWORDS`,
-`esql.AGGREGATE_FUNCTIONS` and `esql.CONDITIONAL_OPERATORS`. Anything that documents or completes
-ESQL should read those rather than keep its own copy.
+`esql.AGGREGATE_FUNCTIONS`, `esql.CONDITIONAL_OPERATORS` and `esql.SEMI_JOIN_OPERATOR`. Anything
+that documents or completes ESQL should read those rather than keep its own copy.
+
+Token sets alone do not say where a token is legal, so `esql.GRAMMAR` carries the per-clause
+shapes: what each clause accepts, which operators it takes, what it requires to be present, and
+whether it repeats. It is plain dicts and lists, so `json.dumps(esql.GRAMMAR)` is the whole export
+step for a consumer that renders a completion menu or a reference table.
+
+```python
+import esql
+
+esql.GRAMMAR["clauses"]["HAVING"]["operators"]   # ['>=', '<=', '!=', '==', '>', '<', '=']
+esql.GRAMMAR["clauses"]["SUCH THAT"]["requires"] # ['OVER']
+esql.GRAMMAR["aggregates"]["numeric_only"]       # ['sum', 'avg', 'min', 'max']
+```
+
+`GRAMMAR` is a description rather than the parser itself, so `tests/parser/test_grammar.py` checks
+every claim it makes by running the parser: each listed operator must parse in that clause and each
+unlisted one must raise. A rule added to the parser without updating the description fails there.
 
 ## ESQL Input Data and Query Syntax
 

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -5,6 +5,8 @@ This document contains information about writing ESQL queries. I will be providi
 
 This document is prose. The token sets it describes — the six keywords, the five aggregate functions, the comparison operators, and the semi-join predicate — are defined once in [`src/esql/parser/util.py`](../../src/esql/parser/util.py) as `KEYWORDS`, `AGGREGATE_FUNCTIONS`, `CONDITIONAL_OPERATORS` and `SEMI_JOIN_OPERATOR`, re-exported from `esql`. Read those if you need the authoritative list.
 
+The per-clause rules this document explains in prose are also available machine-readable as `esql.GRAMMAR` (see [`src/esql/grammar.py`](../../src/esql/grammar.py)): which slot kinds each clause accepts, which operators are legal in it, and what it requires. Anything generating a completion menu or a reference table should read that rather than re-deriving it from this page.
+
 ## Table of Contents
 - [Structure](#structure)
 - [SELECT](#select)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.4.0"
+version = "1.5.0"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/esql/__init__.py
+++ b/src/esql/__init__.py
@@ -1,4 +1,12 @@
 from esql.accessor import ESQLAccessor
+from esql.grammar import GRAMMAR
 from esql.parser.util import AGGREGATE_FUNCTIONS, CONDITIONAL_OPERATORS, KEYWORDS, SEMI_JOIN_OPERATOR
 
-__all__ = ["AGGREGATE_FUNCTIONS", "CONDITIONAL_OPERATORS", "KEYWORDS", "SEMI_JOIN_OPERATOR", "ESQLAccessor"]
+__all__ = [
+    "AGGREGATE_FUNCTIONS",
+    "CONDITIONAL_OPERATORS",
+    "GRAMMAR",
+    "KEYWORDS",
+    "SEMI_JOIN_OPERATOR",
+    "ESQLAccessor",
+]

--- a/src/esql/grammar.py
+++ b/src/esql/grammar.py
@@ -1,0 +1,117 @@
+"""A machine-readable description of the ESQL grammar, for consumers that render it.
+
+The token sets in `parser/util.py` say *what* the tokens are. This says what each clause does with
+them: which slot kinds it accepts, which operators are legal in it, what it requires to be present,
+and whether it repeats. A completion menu needs the second kind to answer "what can go here", and
+until now the only copy of it lived hand-written in the demo front-end, in another repo, where a
+rule added to the parser went unreflected and nothing failed.
+
+Everything here is plain dicts, lists and strings, so `json.dumps(GRAMMAR)` is the whole export
+step. The token sets are read from the parser rather than repeated, and every behavioral claim the
+description makes is asserted against the real parser in `tests/parser/test_grammar.py`. That test
+is what keeps this honest: it is a description, not the implementation, so drift is caught by
+exercising the parser rather than by hoping the two stay in step.
+"""
+
+from esql.parser.types import LogicalOperator
+from esql.parser.util import (
+    AGGREGATE_FUNCTIONS,
+    CONDITIONAL_OPERATORS,
+    DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS,
+    HAVING_OPERATORS,
+    KEYWORDS,
+    NUMERIC_AGGREGATE_FUNCTIONS,
+    SEMI_JOIN_OPERATOR,
+    SUCH_THAT_OPERATORS,
+    TEXT_OPERATORS,
+    WHERE_OPERATORS,
+)
+
+# What can occupy a slot. A clause's "accepts" entry names kinds from here.
+SLOT_KINDS = {
+    "column": "A column of the queried DataFrame.",
+    "aggregate": "`column.function`, or `group.column.function` for a group declared in OVER.",
+    "group_name": "A group declared in OVER. Must match [A-Za-z0-9_]+.",
+    "condition": "A comparison or semi-join, combinable with AND, OR, NOT and parentheses.",
+    "group_condition": "A condition whose every column is prefixed with its group name.",
+    "aggregate_condition": "An aggregate compared against a number.",
+    "grouping_attribute_index": (
+        "A 1-based index into the SELECT grouping attributes. Negative reverses the sort."
+    ),
+}
+
+CLAUSES = {
+    "SELECT": {
+        "required": True,
+        "requires": [],
+        "separator": ",",
+        "accepts": ["column", "aggregate"],
+        "operators": [],
+        "summary": (
+            "Projection. Every plain column is a grouping attribute, and at least one is required, "
+            "so a query of only aggregates is rejected."
+        ),
+    },
+    "OVER": {
+        "required": False,
+        "requires": [],
+        "separator": ",",
+        "accepts": ["group_name"],
+        "operators": [],
+        "summary": "Declares the group names that group-specific aggregates and SUCH THAT sections use.",
+    },
+    "WHERE": {
+        "required": False,
+        "requires": [],
+        "separator": None,
+        "accepts": ["condition"],
+        "operators": list(WHERE_OPERATORS),
+        "summary": "Filters rows before grouping. The only clause that accepts the HAS semi-join.",
+    },
+    "SUCH THAT": {
+        "required": False,
+        "requires": ["OVER"],
+        "separator": ",",
+        "accepts": ["group_condition"],
+        "operators": list(SUCH_THAT_OPERATORS),
+        "summary": (
+            "One section per group, each scoping which rows feed that group's aggregates. A group "
+            "may appear in only one section."
+        ),
+    },
+    "HAVING": {
+        "required": False,
+        "requires": [],
+        "separator": None,
+        "accepts": ["aggregate_condition"],
+        "operators": list(HAVING_OPERATORS),
+        "summary": "Filters grouped rows by comparing an aggregate against a number.",
+    },
+    "ORDER BY": {
+        "required": False,
+        "requires": [],
+        "separator": None,
+        "accepts": ["grouping_attribute_index"],
+        "operators": [],
+        "summary": "Sorts by one of the SELECT grouping attributes, chosen by 1-based position.",
+    },
+}
+
+GRAMMAR = {
+    # Also the order a query must write them in.
+    "keywords": list(KEYWORDS),
+    "clauses": CLAUSES,
+    "slot_kinds": SLOT_KINDS,
+    "aggregates": {
+        "functions": list(AGGREGATE_FUNCTIONS),
+        "forms": ["column.function", "group.column.function"],
+        "numeric_only": list(NUMERIC_AGGREGATE_FUNCTIONS),
+        "any_dtype": list(DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS),
+    },
+    "operators": {
+        "comparison": list(CONDITIONAL_OPERATORS),
+        "text": list(TEXT_OPERATORS),
+        "semi_join": SEMI_JOIN_OPERATOR,
+        "logical": [op.value.upper() for op in LogicalOperator],
+    },
+}

--- a/src/esql/parser/util.py
+++ b/src/esql/parser/util.py
@@ -38,21 +38,35 @@ from esql.parser.types import (
 # The six clause keywords, in the order a query must write them.
 KEYWORDS = ("SELECT", "OVER", "WHERE", "SUCH THAT", "HAVING", "ORDER BY")
 
-# The aggregate functions valid in `column.function` / `group.column.function`. All require a
-# numeric column except `count`, which accepts any dtype.
+# The aggregate functions valid in `column.function` / `group.column.function`.
 AGGREGATE_FUNCTIONS = ("sum", "avg", "min", "max", "count")
 
-# Comparison operators valid in WHERE, SUCH THAT and HAVING conditions. `==` is read as `=`.
-# `CONTAINS` is a case-insensitive substring test over a text column and is the one operator here
-# that is a word rather than a symbol, so it matches only on word boundaries and only in WHERE and
-# SUCH THAT: a HAVING condition compares an aggregate, which is always numeric.
+# `count` asks how many rows, not what they hold, so it is the one function that works on any
+# dtype. `_parse_aggregate` reads this rather than naming `count` itself.
+DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS = ("count",)
+NUMERIC_AGGREGATE_FUNCTIONS = tuple(f for f in AGGREGATE_FUNCTIONS if f not in DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS)
+
+# Comparison operators valid in a condition. `==` is read as `=`.
 CONDITIONAL_OPERATORS = ("CONTAINS", ">=", "<=", "!=", "==", ">", "<", "=")
 
-# The semi-join predicate, valid only in WHERE. `<key> HAS <condition>` keeps rows whose `<key>`
-# value belongs to some row satisfying `<condition>`, which is how a query reaches across grains
-# without a join. It is not a comparison and so is not one of CONDITIONAL_OPERATORS: what follows
-# it is a whole condition, not a value.
+# Operators that compare text rather than order it. `CONTAINS` is a case-insensitive substring
+# test and is the one operator here that is a word rather than a symbol, so it matches only on
+# word boundaries.
+TEXT_OPERATORS = ("CONTAINS",)
+
+# The semi-join predicate. `<key> HAS <condition>` keeps rows whose `<key>` value belongs to some
+# row satisfying `<condition>`, which is how a query reaches across grains without a join. It is
+# not a comparison and so is not one of CONDITIONAL_OPERATORS: what follows it is a whole
+# condition, not a value.
 SEMI_JOIN_OPERATOR = "HAS"
+
+# Which operators each clause accepts. WHERE filters raw rows, so it takes everything. SUCH THAT
+# scopes a group and runs over the same rows, so it takes the comparisons but not the semi-join,
+# which filters before grouping. HAVING compares an aggregate, and every aggregate is numeric, so
+# it takes neither the text operators nor the semi-join.
+WHERE_OPERATORS = (*CONDITIONAL_OPERATORS, SEMI_JOIN_OPERATOR)
+SUCH_THAT_OPERATORS = CONDITIONAL_OPERATORS
+HAVING_OPERATORS = tuple(op for op in CONDITIONAL_OPERATORS if op not in TEXT_OPERATORS)
 
 
 ###########################################################################
@@ -520,7 +534,9 @@ def _parse_aggregate(
             raise ParsingError(error_type, f"Invalid aggregate column: '{aggregate}'", token=aggregate)
         elif func not in AGGREGATE_FUNCTIONS:
             raise ParsingError(error_type, f"Invalid aggregate function: '{aggregate}'", token=aggregate)
-        elif func != "count" and not (pd.api.types.is_any_real_numeric_dtype(column_dtypes[column])):
+        elif func not in DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS and not (
+            pd.api.types.is_any_real_numeric_dtype(column_dtypes[column])
+        ):
             raise ParsingError(
                 error_type, f"Invalid aggregate. Column is not a numeric type: '{aggregate}'", token=aggregate
             )
@@ -535,7 +551,9 @@ def _parse_aggregate(
             raise ParsingError(error_type, f"Invalid aggregate column: '{aggregate}'", token=aggregate)
         elif func not in AGGREGATE_FUNCTIONS:
             raise ParsingError(error_type, f"Invalid aggregate function: '{aggregate}'", token=aggregate)
-        elif func != "count" and not (pd.api.types.is_any_real_numeric_dtype(column_dtypes[column])):
+        elif func not in DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS and not (
+            pd.api.types.is_any_real_numeric_dtype(column_dtypes[column])
+        ):
             raise ParsingError(
                 error_type, f"Invalid aggregate. Column is not a numeric type: '{aggregate}'", token=aggregate
             )

--- a/tests/parser/test_grammar.py
+++ b/tests/parser/test_grammar.py
@@ -1,0 +1,159 @@
+"""Assert `esql.GRAMMAR` against the parser it describes.
+
+GRAMMAR is a description, not the implementation, so on its own it is just a second copy of rules
+the parser already enforces, which is the drift this was built to remove. These tests are what
+close that gap: each claim in the description is checked by running the real parser through
+`df.esql.validate(...)` and seeing whether it accepts or rejects.
+
+The operator coverage test is the important one. For every clause it asserts both directions, that
+each listed operator parses and each unlisted one raises, so adding an operator to the grammar
+without teaching a clause about it fails here rather than silently reaching the demo.
+"""
+
+import json
+
+import pandas as pd
+import pytest
+
+from esql.grammar import GRAMMAR
+from esql.parser.error import ParsingError
+from esql.parser.util import (
+    AGGREGATE_FUNCTIONS,
+    CONDITIONAL_OPERATORS,
+    KEYWORDS,
+    SEMI_JOIN_OPERATOR,
+)
+
+ALL_OPERATORS = (*CONDITIONAL_OPERATORS, SEMI_JOIN_OPERATOR)
+
+
+@pytest.fixture
+def data() -> pd.DataFrame:
+    return pd.DataFrame({"cust": ["a", "b"], "prod": ["x", "y"], "quant": [1, 2]})
+
+
+def _condition(operator: str, prefix: str = "") -> str:
+    """A minimal valid condition using `operator`, prefixed for SUCH THAT's group notation."""
+    if operator in GRAMMAR["operators"]["text"]:
+        return f"{prefix}prod {operator} 'x'"
+    if operator == SEMI_JOIN_OPERATOR:
+        return f"{prefix}prod {operator} {prefix}quant > 1"
+    return f"{prefix}quant {operator} 1"
+
+
+def _query_using(clause: str, operator: str) -> str:
+    if clause == "WHERE":
+        return f"SELECT cust, quant.sum WHERE {_condition(operator)}"
+    if clause == "SUCH THAT":
+        return f"SELECT cust, g1.quant.sum OVER g1 SUCH THAT {_condition(operator, prefix='g1.')}"
+    if clause == "HAVING":
+        if operator in GRAMMAR["operators"]["text"]:
+            return f"SELECT cust, quant.sum HAVING quant.sum {operator} 'x'"
+        if operator == SEMI_JOIN_OPERATOR:
+            return f"SELECT cust, quant.sum HAVING quant.sum {operator} prod = 'x'"
+        return f"SELECT cust, quant.sum HAVING quant.sum {operator} 1"
+    raise AssertionError(f"no query template for clause {clause}")
+
+
+###############################################################################
+# Shape
+###############################################################################
+def test_grammar_is_json_serializable():
+    # The whole export step downstream is json.dumps, so a non-serializable value breaks the build.
+    assert json.loads(json.dumps(GRAMMAR)) == GRAMMAR
+
+
+def test_grammar_describes_exactly_the_real_clauses():
+    assert GRAMMAR["keywords"] == list(KEYWORDS)
+    assert list(GRAMMAR["clauses"]) == list(KEYWORDS)
+
+
+def test_every_accepted_slot_kind_is_defined():
+    for clause, shape in GRAMMAR["clauses"].items():
+        for kind in shape["accepts"]:
+            assert kind in GRAMMAR["slot_kinds"], f"{clause} accepts undefined slot kind {kind!r}"
+
+
+def test_every_described_operator_is_a_real_operator():
+    for clause, shape in GRAMMAR["clauses"].items():
+        for operator in shape["operators"]:
+            assert operator in ALL_OPERATORS, f"{clause} lists unknown operator {operator!r}"
+
+
+def test_aggregate_functions_are_partitioned_by_dtype_rule():
+    described = GRAMMAR["aggregates"]
+    assert described["functions"] == list(AGGREGATE_FUNCTIONS)
+    assert sorted(described["numeric_only"] + described["any_dtype"]) == sorted(AGGREGATE_FUNCTIONS)
+    assert not set(described["numeric_only"]) & set(described["any_dtype"])
+
+
+###############################################################################
+# The description against the parser
+###############################################################################
+@pytest.mark.parametrize("clause", ["WHERE", "SUCH THAT", "HAVING"])
+def test_listed_operators_parse_and_unlisted_ones_raise(clause: str, data: pd.DataFrame):
+    allowed = set(GRAMMAR["clauses"][clause]["operators"])
+    assert allowed, f"{clause} should list operators"
+
+    for operator in ALL_OPERATORS:
+        query = _query_using(clause, operator)
+        if operator in allowed:
+            data.esql.validate(query)  # must not raise
+        else:
+            with pytest.raises(ParsingError):
+                data.esql.validate(query)
+
+
+@pytest.mark.parametrize("function", GRAMMAR["aggregates"]["numeric_only"])
+def test_numeric_only_aggregates_reject_a_text_column(function: str, data: pd.DataFrame):
+    with pytest.raises(ParsingError, match="not a numeric type"):
+        data.esql.validate(f"SELECT cust, prod.{function}")
+
+
+@pytest.mark.parametrize("function", GRAMMAR["aggregates"]["any_dtype"])
+def test_dtype_agnostic_aggregates_accept_a_text_column(function: str, data: pd.DataFrame):
+    data.esql.validate(f"SELECT cust, prod.{function}")
+
+
+@pytest.mark.parametrize("form", GRAMMAR["aggregates"]["forms"])
+def test_both_aggregate_forms_parse(form: str, data: pd.DataFrame):
+    aggregate = form.replace("group", "g1").replace("column", "quant").replace("function", "sum")
+    over = " OVER g1" if "g1." in aggregate else ""
+    data.esql.validate(f"SELECT cust, {aggregate}{over}")
+
+
+def test_such_that_requires_over_as_described(data: pd.DataFrame):
+    assert GRAMMAR["clauses"]["SUCH THAT"]["requires"] == ["OVER"]
+    # Without OVER there is no group for the section to scope, so the group reference is rejected.
+    with pytest.raises(ParsingError):
+        data.esql.validate("SELECT cust, g1.quant.sum SUCH THAT g1.prod = 'x'")
+
+
+def test_select_is_the_only_required_clause(data: pd.DataFrame):
+    required = [clause for clause, shape in GRAMMAR["clauses"].items() if shape["required"]]
+    assert required == ["SELECT"]
+    # Every other clause is genuinely omittable: SELECT alone parses.
+    data.esql.validate("SELECT cust, quant.sum")
+
+
+def test_select_needs_a_grouping_attribute_as_described(data: pd.DataFrame):
+    assert "column" in GRAMMAR["clauses"]["SELECT"]["accepts"]
+    with pytest.raises(ParsingError, match="No grouping attributes"):
+        data.esql.validate("SELECT quant.sum")
+
+
+def test_clause_order_follows_the_described_keyword_order(data: pd.DataFrame):
+    # HAVING before WHERE inverts the documented order and must be rejected.
+    assert GRAMMAR["keywords"].index("WHERE") < GRAMMAR["keywords"].index("HAVING")
+    with pytest.raises(ParsingError, match="Unexpected position"):
+        data.esql.validate("SELECT cust, quant.sum HAVING quant.sum > 0 WHERE quant > 0")
+
+
+@pytest.mark.parametrize("clause", ["SELECT", "OVER", "SUCH THAT"])
+def test_comma_separated_clauses_are_described_as_such(clause: str):
+    assert GRAMMAR["clauses"][clause]["separator"] == ","
+
+
+def test_repeating_a_group_across_such_that_sections_is_rejected(data: pd.DataFrame):
+    with pytest.raises(ParsingError, match="Multiple sections"):
+        data.esql.validate("SELECT cust, g1.quant.sum OVER g1 SUCH THAT g1.prod = 'x', g1.quant > 1")

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
Two commits. The Makefile fix is independent and first, so it can be read on its own.

## `make typecheck` never ran

The target called `uv run mypy`, whose console script fails to spawn. So the target errored out before reaching mypy, and had been doing so for however long. The recorded error count was stale as a result: `status.md` said 143, the real number is 156. Now `uv run python -m mypy`, the form every other target already uses. The cleanup pass itself stays open.

## `esql.GRAMMAR` (Stream G1)

The exported token sets said *what* the tokens are. Nothing said *where each is legal*. The demo front-end kept that second half hand-written in another repo, so a rule added to the parser went unreflected downstream and nothing failed. CONTAINS and HAS just demonstrated it: both reached the demo for free through the exported constants, but the rules about which clauses accept them did not.

`GRAMMAR` carries the missing half. Per clause: what it accepts, which operators it takes, what it requires to be present, whether it repeats. Plus a slot-kind glossary and the aggregate dtype rule. Plain dicts and lists, so `json.dumps(esql.GRAMMAR)` is the whole export step.

```python
esql.GRAMMAR["clauses"]["HAVING"]["operators"]   # ['>=', '<=', '!=', '==', '>', '<', '=']
esql.GRAMMAR["clauses"]["SUCH THAT"]["requires"] # ['OVER']
esql.GRAMMAR["aggregates"]["numeric_only"]       # ['sum', 'avg', 'min', 'max']
```

### What "generated from the parser" actually amounts to

Worth being straight about, since the tracked item asked for generation rather than restatement.

Part of it **is** genuinely single sourced. `WHERE_OPERATORS`, `SUCH_THAT_OPERATORS`, `HAVING_OPERATORS`, `TEXT_OPERATORS` and `DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS` are constants the parser reads, and `_parse_aggregate` no longer names `count` itself.

The rest cannot be generated. The parser is imperative code, not a declarative grammar, so there is nothing to mechanically derive from without restructuring it, which is not worth the cost. `GRAMMAR` is therefore a description, and `tests/parser/test_grammar.py` is what keeps it honest rather than making it a second copy. It runs the real parser through `validate()` and asserts, for every clause, that each listed operator parses and each unlisted one raises. Also the aggregate dtype split, the SUCH THAT/OVER dependency, clause order, and the SELECT grouping requirement.

I checked the guard bites rather than assuming it: making `HAVING_OPERATORS` claim `CONTAINS` fails `test_listed_operators_parse_and_unlisted_ones_raise[HAVING]` instead of reaching the demo.

That kills the silent-drift failure mode, which was the point. It does not make the description generated, and the tracked item is marked accordingly.

## Follow-on

G2 (a guard for the hand-written clause reference cards) now has something to check against: the cards can be generated from `GRAMMAR` or asserted to agree with it.

## Gate

`make check` green at **142 tests**, up from 119. Wheel builds at `1.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)