### PR TITLE
v1.9.0: resolve identifiers case-insensitively instead of folding the query (K1, K2)

### DIFF
--- a/.claude/status.md
+++ b/.claude/status.md
@@ -277,13 +277,17 @@ H1 shipped; see the settled record. What it leaves open:
 
 Opened 2026-07-29. Findings from the v1.8.0 work that are **not** about a missing feature: the
 parser accepts a query and answers it wrongly, or refuses one it should take. J4 was the first of
-these and is fixed; these two were turned up alongside it and are not.
+these and is fixed; these two were turned up alongside it. **Both shipped in v1.9.0**; see that entry
+in the settled record. The stream is closed unless something new lands in it.
 
 The shape they share with J4 is worth naming, because it is what to look for next: **a rule the
 parser applies by rewriting the query string before it knows the query's structure.** Lowercasing
-the whole query was the J4 root, and K1 is the other half of the same pass.
+the whole query was the J4 root, and K1 was the other half of the same pass. With the fold gone,
+`_prepare_query` now rewrites only whitespace, so nothing in the parser depends on a string
+substitution made before the structure is known. That whole failure mode is closed rather than
+patched twice.
 
-- [ ] **K1. A mixed-case DataFrame column cannot be queried at all.** Found while fixing J4, by
+- [x] **K1. A mixed-case DataFrame column cannot be queried at all.** Found while fixing J4, by
   testing what `_prepare_query` does rather than reading it. Hand the accessor a frame whose columns
   are `Cust` and `Quant` and **every spelling fails**:
 
@@ -309,7 +313,9 @@ the whole query was the J4 root, and K1 is the other half of the same pass.
   lowercase throughout, which is why it has gone unnoticed. It bites the first person who points the
   accessor at their own frame, which is the entire published use.
 
-- [ ] **K2. Two default arguments are dead, and read as if they were not.** `_parse_condition_value`
+  **Fixed in v1.9.0**, as filed: the fold is gone and the twelve sites go through `_resolve_column`.
+
+- [x] **K2. Two default arguments are dead, and read as if they were not.** `_parse_condition_value`
   and `_parse_aggregate` each default `error_type` to `A or B`:
 
   ```python
@@ -323,6 +329,9 @@ the whole query was the J4 root, and K1 is the other half of the same pass.
   caller and does not, sitting in the function that reports which clause rejected a value. Delete
   the defaults and make the parameter required, so a future caller cannot silently inherit
   `SELECT CLAUSE` for a WHERE failure.
+
+  **Done in v1.9.0.** Both parameters are required and
+  `test_error_type_is_a_required_argument` pins that, so a default cannot come back.
 
 ---
 
@@ -446,7 +455,7 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   `public/docs/syntax.md` section + an ESQL demo example. Pairs with HAS: HAS
   *filters* one grain by another; this *measures* across grains. Design captured now; build parked
   until the datasets/rename plumbing lands.
-- [ ] **mypy clean pass.** 159 errors (recorded as 156 until v1.8.0 measured it again; the count was
+- [ ] **mypy clean pass.** 157 errors (159 before v1.9.0, and recorded as 156 until v1.8.0; the count was
   stale at 143 before that because `make typecheck` called
   `uv run mypy`, whose console script does not spawn, so the target errored out before reaching
   mypy; fixed in v1.5.0 to `uv run python -m mypy`, the form every other target uses). All from
@@ -660,7 +669,86 @@ All fixed and covered by the now-meaningful integration suite (see §3).
 
   **What this turned up and did not fix** is filed as **Stream K** above: a mixed-case DataFrame
   column is unreachable in any spelling (K1, the other half of the same `_prepare_query` pass), and
-  two dead `A or B` default arguments (K2).
+  two dead `A or B` default arguments (K2). Both shipped in v1.9.0, below.
+
+## v1.9.0 — identifiers resolve instead of being folded (2026-07-29)
+
+- [x] **K1 and K2.** A frame whose columns are `Cust` and `Quant` is now queryable, in any spelling,
+  and the two dead `A or B` defaults are gone. Bumped `1.8.0 -> 1.9.0`; the gate is green at
+  **247 tests** (was 230).
+
+  **The fix is a deletion, not an addition.** `_prepare_query` no longer lowercases; it collapses
+  whitespace and nothing else. Everything the fold was silently doing for the parser now happens
+  where the structure is known:
+
+  - **Keywords and operators fold case themselves.** `get_keyword_clauses` searches with
+    `re.IGNORECASE`, and `_operator_starts_at` already compared case-insensitively — it just carried
+    a comment crediting `_prepare_query` for it. The AND/OR split, the NOT prefix and the
+    `true`/`false` literals were likewise already folding on their own. So four of the six things the
+    fold appeared to be responsible for did not need it at all, which is why the change is small.
+  - **Identifiers resolve through `_resolve_column` / `_resolve_group`**, which answer with the
+    **canonical** spelling: the frame's for a column, the OVER clause's for a group. This is the part
+    that makes the fix work rather than just move the bug. Execution indexes rows by the frame's
+    spelling (`execute.column_indices`), so a parsed query carrying the *query's* spelling would
+    reach the row loop and fail there instead. All twelve `column_dtypes` sites route through the one
+    resolver.
+  - **An aggregate function lowercases** to its canonical name, so `QUANT.SUM` and `quant.sum` are
+    the same aggregate. That matters beyond cosmetics: the SELECT/HAVING dedup in
+    `_build_parsed_query` compares parsed aggregates, so without it `SELECT quant.sum HAVING
+    QUANT.SUM > 0` would accumulate twice per row and silently double the sum — BUG-8 from v1.1
+    arriving by a new route. Covered.
+
+  Decisions worth keeping:
+
+  - **Resolution tries an exact match first, then a case-folded one.** A frame *can* hold `Cust` and
+    `cust` at once, and exact-first keeps both reachable by writing either. Only a third spelling
+    (`CUST`) is genuinely ambiguous, and that raises and names both candidates rather than picking
+    one. Rejecting the whole frame up front was the alternative and is worse: it refuses queries
+    that have one obvious answer.
+  - **Two group names differing only in case are rejected.** They name the same group, so
+    `_resolve_group` would have an ambiguous case to answer. Rejecting in `parse_over_clause` is
+    where the information is, and it subsumes the exact-duplicate `OVER g1, g1`, which used to parse
+    and mean nothing.
+  - **The result is labelled canonically, not as the query wrote it.** `SELECT CUST, QUANT.SUM`
+    returns columns `Cust` and `Quant.sum`. The label is also the key execution looks the value up
+    by, so a query-spelled label would find nothing in the grouped row's data map; making it
+    canonical is what keeps the two in step by construction rather than by both being lowercase.
+  - **`ParsingError.token` now comes back spelled exactly as the query spelled it.** This is a
+    published contract *improvement* and the one visible behavior change beyond the fix: a token used
+    to be lowercased, so `README.md` told a consumer to match it case-insensitively. It matches
+    literally now. Both README and the `ParsingError` docstring were saying the old thing.
+  - **`aggregate_key` has one home.** The `column.function` / `group.column.function` key was three
+    f-strings in three files — the parser's select items, `GroupedRow`, and the HAVING evaluator —
+    which agreed only because everything was lowercase. Once identifiers carry the frame's spelling
+    they have to be built by the same code, so it moved to `parser/types.py`. A mismatch here is
+    silent: the projected column comes back empty rather than raising.
+
+  Covered by `tests/parser/test_identifier_case.py` (17 tests) exercising every clause against a
+  frame that is mixed-case throughout, which is the case that used to be unreachable, plus the two
+  existing tests that asserted the old behavior and were inverted
+  (`_prepare_query` and the error token). Verified the suite bites, by reverting each part of the fix
+  in turn: restoring the fold fails 4, making `_resolve_column` exact-only fails 12, pointing
+  `select_items_in_order` back at the written text fails 6, dropping `re.IGNORECASE` fails 13, and
+  making `_names_group` case-sensitive fails 2.
+
+  **Prose updated to match**, because `public/docs/syntax.md` already claimed "ESQL is not case
+  sensitive" and that claim was **false** for the entire published use. It now has a **Case** section
+  saying what is folded, what is not, and what a result is labelled with; the OVER section names the
+  case-collision rule; and `README.md` says it in the accessor walkthrough, since pointing the
+  accessor at your own frame is where this bit.
+
+  **Considered and declined: publishing the case rule in `GRAMMAR`.** It is the kind of rule a host
+  could mirror wrongly, which is the Stream G argument for exporting it. But no host needs it: a
+  caret menu inserts canonical names off the dataset asset, and a host pre-checking a typed query
+  calls `validate`, which now answers correctly. Following the same discipline G3 records — do not
+  publish surface before there is a reader — it stays prose. Reopen if a consumer needs to decide
+  legality for itself.
+
+  **Portfolio-side follow-up: none required.** No new name in `esql.__all__`, no new slot kind and no
+  new `GRAMMAR` key, so neither the export-diff guard nor the `unhandledSlotKinds` check fires. Both
+  portfolio datasets are lowercase throughout, so every result label is byte-identical to 1.8.0. The
+  one thing worth knowing is that `ParsingError.token` is now literal, which makes portfolio's
+  existing case-insensitive match correct but no longer necessary.
 
   **Portfolio-side follow-up, optional.** No export guard fires: `literals` is a new key inside
   `GRAMMAR` rather than a new name in `esql.__all__`, and no slot kind changed, so `grammar.json`

--- a/.claude/status.md
+++ b/.claude/status.md
@@ -204,6 +204,53 @@ clause gaining a rule upstream simply goes unreflected downstream.
 
 H1 shipped; see the settled record. What it leaves open:
 
+- [ ] **H4. `count` should count rows bare, and count *distinct* on a column.** Filed from portfolio
+  2026-07-29, from a visitor reading a result and being wrong about it in the way the syntax invites.
+
+  **What happened.** `SELECT state, city.count` returns 11,963 for CA. That is the row count — CA has
+  11,963 song-performances and **61 distinct cities**. The reader expected 61, which is what the
+  syntax says: under a clause that auto-groups, `city.count` reads as "the cities, counted".
+
+  **The column is doing nothing.** `city.count`, `song.count` and `position.count` all return 11,963
+  for CA; only `duration.count` differs (10,850), and only because it has 3,269 nulls. So the column
+  in `X.count` carries no meaning except its nullness. It is there to satisfy dot-notation, and
+  naming a column that has no bearing on the answer is what makes the result misread.
+
+  **The root cause is that ESQL has no `COUNT(*)`.** SQL can count rows without naming a column;
+  dot-notation cannot, so every row count borrows a column, and auto-grouping turns the borrowed name
+  into an apparent meaning. All 13 curated demo examples borrow `position` this way.
+
+  **The proposal, which is the dataset owner's call and their preference:**
+
+  - `count` — bare, no column: the row count. The `COUNT(*)` that is missing today.
+  - `column.count` — the **distinct** values of that column. What the syntax already looks like.
+  - `sum` / `avg` / `min` / `max` — unchanged, over rows.
+
+  Two objections were raised from portfolio and both were overruled, correctly. That old queries
+  change meaning does not matter: every query that exists is in the demo and gets rewritten. That
+  `sum / count` would stop equalling `avg` is a SQL identity, not a law — if `count` is defined as
+  distinct then the identity simply does not hold, and `avg` keeps its own definition.
+
+  What makes it worth the migration is that it removes the misleading form rather than documenting
+  it: after this, there is no way to spell "row count" that names an irrelevant column.
+
+  **Two things to decide, both affecting what portfolio can read:**
+
+  1. **`aggregates.forms` grows a bare form.** It currently publishes
+     `["column.function", "group.column.function"]`. A bare `count` is a third shape, and if a group
+     can take one (`g1.count`, the group's row count — expected for symmetry with `g1.column.count`)
+     a fourth. Portfolio's result table decides what is a *measure* by looking for a dot with an
+     aggregate name after it, so a bare `count` column would be filed as a **dimension** and rendered
+     in the label block instead of as a number. That is fixed by reading `forms` instead of assuming
+     a dot, which portfolio is doing now — but only works if `forms` actually carries the new shape.
+  2. **`aggregates.any_dtype` narrows.** "Only `count` is legal on a non-numeric column" would govern
+     only `column.count`, since the bare form takes no column at all.
+
+  **Sequencing: land it with D1** (splitting `position` into set position and show position). Both
+  rewrite all 13 curated examples, the walkthrough, `songs.structure.json` and every SQL equivalent
+  the docs show side by side. Doing them separately means paying that twice, and `esql-smoke` catches
+  a partial migration either way.
+
 - [ ] **H3. `ORDER BY` cannot sort by an aggregate.** Filed from portfolio 2026-07-29.
   `SELECT song, position.count ORDER BY position.count` raises `[ORDER_BY_CLAUSE] Invalid value`, and
   `ORDER BY 2` raises "out of range of the 1 grouping attributes" — confirming the index counts only

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ from esql import ESQLAccessor
 new_df = df.esql.query("SELECT cust, prod, quant.avg")
 ```
 
+Queries are not case sensitive, and neither is matching a name in the query against a column of your
+frame, so a frame whose columns are `Cust` and `Quant` takes `SELECT Cust, Quant.avg` and
+`SELECT cust, quant.avg` alike. The result is labelled with your frame's spelling rather than the
+query's, so the column names you get back do not depend on how the query was typed. A text value is
+the exception and stays case sensitive, because its contents are data: see
+[Case](public/docs/syntax.md#case).
+
 Aggregates are rounded to 2 decimal places by default. You can change this by passing a different value to the query as `decimal_places`.
 
 ```python
@@ -124,8 +131,9 @@ except ParsingError as e:
 Parsing is the cheap half of a query — microseconds against tens of milliseconds — so this is
 usable for live feedback while someone is still typing. `token` is what lets an editor point at the
 mistake rather than only name the clause. It is a fragment and not a character offset because the
-parser runs on a lowercased, whitespace-collapsed copy of the query, so offsets into it do not map
-back onto what was typed; match it case-insensitively.
+parser runs on a whitespace-collapsed copy of the query, so offsets into it do not map back onto
+what was typed. The fragment itself is spelled exactly as the query spelled it, so a literal match
+finds it.
 
 The token sets the parser accepts are exported for the same reason: `esql.KEYWORDS`,
 `esql.AGGREGATE_FUNCTIONS`, `esql.CONDITIONAL_OPERATORS` and `esql.SEMI_JOIN_OPERATOR`. Anything

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -38,7 +38,14 @@ ORDER BY [variable order]
 
 The query language has 6 keywords: SELECT, OVER, WHERE, SUCH THAT, HAVING, and ORDER BY. The follpowing sections explore the the syntax and use cases of each keyword. ESQL queries do not contain a FROM clause like in SQL since a datatable must be passed in through the DataFrame accessor or through the API. Queries do not require all of the keywords, but variable projection (in the [SELECT](#select) clause) must be performed for the query to produce an output.
 
-ESQL is not case sensitive, including the keywords. Only string comparison in the WHERE and SUCH THAT clauses are case sensitive. The exception is [`CONTAINS`](#where), which is deliberately case insensitive. 
+### Case
+
+ESQL is not case sensitive. Keywords, operators, column names, group names and aggregate functions can be written in any case, so `SELECT Cust, QUANT.SUM` and `select cust, quant.sum` are the same query. A column name is matched against the DataFrame's columns without regard to case, so a frame whose columns are `Cust` and `Quant` is queryable however you spell them.
+
+What is case sensitive is a **text value**, because its contents are data rather than a spelling: `WHERE prod = 'Ham'` and `WHERE prod = 'HAM'` are different filters. The exception is [`CONTAINS`](#where), which is deliberately case insensitive.
+
+A result is labelled with the *canonical* spelling rather than the query's, so the same query returns the same column names whatever case it was typed in: a column as the DataFrame spells it, a group as the [OVER](#over) clause declared it, and an aggregate function in lower case. `SELECT CUST, QUANT.SUM` over a frame with a `Cust` column returns columns `Cust` and `Quant.sum`.
+
 
 ### Text values
 
@@ -83,7 +90,7 @@ If you wanted to write a query with the grouping attributes `cust` and `prod` th
 
 ## OVER
 
-The OVER clause determines the names of the groups that are used to compute aggregates within the conditions set in the [SUCH THAT](#such-that) clause. The groups names are separated by commans. Group names can only include letters, numbers, and `_`, and they are not case sensitive. It is recommended that group names are short and concise.
+The OVER clause determines the names of the groups that are used to compute aggregates within the conditions set in the [SUCH THAT](#such-that) clause. The groups names are separated by commans. Group names can only include letters, numbers, and `_`, and they are not case sensitive: `OVER G1` can be referenced as `g1` anywhere below. Because they are not case sensitive, two names differing only in case would name the same group and are rejected. It is recommended that group names are short and concise.
 
 If you want to define two groups with the names `g1` and `g2`, like in the SELECT clause example above, you would write:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.8.0"
+version = "1.9.0"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/esql/execution/algorithms.py
+++ b/src/esql/execution/algorithms.py
@@ -11,6 +11,7 @@ from esql.parser.types import (
     ParsedSelectClause,
     ParsedSuchThatClause,
     ParsedWhereClause,
+    aggregate_key,
 )
 from esql.parser.util import find_group_in_such_that_section
 
@@ -329,18 +330,13 @@ def _evaluate_having_clause(condition: ParsedHavingClause, data_map: dict[str, s
             raise RuntimeError(f"Unknown logical operator in HAVING clause: '{operator}'")
 
     condition_aggregate = condition.get("aggregate")
-    if "function" in condition_aggregate:
-        if "group" in condition_aggregate:
-            aggregate_key = (
-                f"{condition_aggregate['group']}.{condition_aggregate['column']}.{condition_aggregate['function']}"
-            )
-        else:
-            aggregate_key = f"{condition_aggregate['column']}.{condition_aggregate['function']}"
-    else:
+    if "function" not in condition_aggregate:
         raise RuntimeError(f"Could not recognize the condition in the HAVING clause: '{condition}'")
 
     return _evaluate_actual_vs_expected_value(
-        actual_value=data_map.get(aggregate_key), operator=operator, condition_value=condition.get("value")
+        actual_value=data_map.get(aggregate_key(condition_aggregate)),
+        operator=operator,
+        condition_value=condition.get("value"),
     )
 
 

--- a/src/esql/execution/grouped_row.py
+++ b/src/esql/execution/grouped_row.py
@@ -2,7 +2,7 @@ from datetime import date
 
 import pandas as pd
 
-from esql.parser.types import AggregatesDict, GlobalAggregate, GroupAggregate
+from esql.parser.types import AggregatesDict, GlobalAggregate, GroupAggregate, aggregate_key
 
 
 class GroupedRow:
@@ -36,13 +36,13 @@ class GroupedRow:
             value = self._initial_row[index]
             if pd.isna(value):
                 continue
-            aggregate_key = self._aggregate_key(aggregate)
+            key = aggregate_key(aggregate)
             if function in ["sum", "min", "max"]:
-                data_map[aggregate_key] = value
+                data_map[key] = value
             elif function == "count":
-                data_map[aggregate_key] = 1
+                data_map[key] = 1
             elif function == "avg":
-                data_map[aggregate_key] = {"sum": value, "count": 1}
+                data_map[key] = {"sum": value, "count": 1}
         return data_map
 
     def update_data_map(self, aggregate: GlobalAggregate | GroupAggregate, row: list[str | int | bool | date]) -> None:
@@ -52,46 +52,40 @@ class GroupedRow:
         value = row[index]
         if pd.isna(value):
             return
-        aggregate_key = self._aggregate_key(aggregate)
-        if aggregate_key not in self._data_map:
+        key = aggregate_key(aggregate)
+        if key not in self._data_map:
             if function in ["sum", "min", "max"]:
-                self._data_map[aggregate_key] = value
+                self._data_map[key] = value
             elif function == "count":
-                self._data_map[aggregate_key] = 1
+                self._data_map[key] = 1
             elif function == "avg":
-                self._data_map[aggregate_key] = {"sum": value, "count": 1}
+                self._data_map[key] = {"sum": value, "count": 1}
         else:
             if function == "sum":
-                self._data_map[aggregate_key] += value
+                self._data_map[key] += value
             elif function == "min":
-                if value < self._data_map[aggregate_key]:
-                    self._data_map[aggregate_key] = value
+                if value < self._data_map[key]:
+                    self._data_map[key] = value
             elif function == "max":
-                if value > self._data_map[aggregate_key]:
-                    self._data_map[aggregate_key] = value
+                if value > self._data_map[key]:
+                    self._data_map[key] = value
             elif function == "count":
-                self._data_map[aggregate_key] += 1
+                self._data_map[key] += 1
             elif function == "avg":
-                values = self._data_map[aggregate_key]
+                values = self._data_map[key]
                 new_sum = values["sum"] + value
                 new_count = values["count"] + 1
-                self._data_map[aggregate_key] = {"sum": new_sum, "count": new_count}
+                self._data_map[key] = {"sum": new_sum, "count": new_count}
 
     # This must be called on all GroupedRows after they have been filtered by the WHERE and SUCH THAT clauses
     def convert_avg_in_data_map(self) -> None:
         for aggregate in self.aggregates["global_scope"] + self.aggregates["group_specific"]:
             if aggregate["function"] == "avg":
-                aggregate_key = self._aggregate_key(aggregate)
-                if self._data_map.get(aggregate_key):
-                    _sum, _count = self._data_map[aggregate_key]["sum"], self._data_map[aggregate_key]["count"]
+                key = aggregate_key(aggregate)
+                if self._data_map.get(key):
+                    _sum, _count = self._data_map[key]["sum"], self._data_map[key]["count"]
                     _avg = _sum / _count
-                    self._data_map[aggregate_key] = _avg
-
-    def _aggregate_key(self, aggregate: GlobalAggregate | GroupAggregate) -> str:
-        if "group" in aggregate:
-            return f"{aggregate['group']}.{aggregate['column']}.{aggregate['function']}"
-        else:
-            return f"{aggregate['column']}.{aggregate['function']}"
+                    self._data_map[key] = _avg
 
     @property
     def data_map(self):

--- a/src/esql/parser/error.py
+++ b/src/esql/parser/error.py
@@ -24,9 +24,14 @@ class ParsingError(Exception):
     than only naming the clause it fell in.
 
     It is a token and not a character offset on purpose: the parser runs on a query that
-    `_prepare_query` has lowercased and whitespace-collapsed outside its string literals, so
-    offsets into it do not map back onto what the user typed, while the token still matches
-    (case-insensitively). Errors about the query as a whole carry no token.
+    `_prepare_query` has whitespace-collapsed outside its string literals, so offsets into it do not
+    map back onto what the user typed, while the token still matches literally. Errors about the
+    query as a whole carry no token.
+
+    Literally as of v1.9.0. `_prepare_query` used to lowercase the query as well, so a token came
+    back lowered and a caller had to fold case to find it. That fold is what made a mixed-case
+    DataFrame column unreachable (`.claude/status.md`, K1), and removing it means a token is now
+    spelled exactly as the query spelled it.
     """
 
     def __init__(self, error_type: ParsingErrorType, message: str, token: str | None = None):

--- a/src/esql/parser/parse.py
+++ b/src/esql/parser/parse.py
@@ -21,30 +21,37 @@ def get_parsed_query(data: pd.DataFrame, query: str) -> ParsedQuery:
 
 
 def _prepare_query(query: str) -> str:
-    """Canonicalize a query for parsing: lowercase it and collapse its whitespace, outside string
-    literals only.
+    """Canonicalize a query for parsing: collapse its whitespace, outside string literals only.
 
-    Keywords, identifiers and operators are case-insensitive, so folding them here means the rest
-    of the parser only ever sees one spelling. A literal is the opposite: its contents are data, so
-    its case and its internal spacing are carried through exactly as written.
+    Whitespace between tokens is formatting, so collapsing it here means the rest of the parser only
+    ever sees single spaces. A literal is the opposite: its contents are data, so its internal
+    spacing is carried through exactly as written.
 
     Telling the two apart is what `literal_spans` is for, and getting it wrong here is what made a
     value holding an apostrophe silently match nothing (`.claude/status.md`, J4). The old pass
     found literals with the regex `'[^']*'`, which closes at the first quote it meets rather than
     at the one that ends the literal.
+
+    **It used to lowercase the query too, and that is what put a mixed-case DataFrame column out of
+    reach in every spelling** (K1). Case cannot be folded here, because here there is no structure
+    yet: a word is not known to be a keyword rather than an identifier until the query has been
+    split into clauses, and an identifier has to keep its case to be matched against a frame whose
+    columns keep theirs. Case-insensitivity now lives where the structure is known, in the keyword
+    and operator matches (which fold case themselves) and in `_resolve_column` / `_resolve_group`,
+    which answer with the *frame's* spelling so the parsed query is what execution can index by.
     """
     prepared = []
     cursor = 0
     for start, end in literal_spans(query):
-        prepared.append(_fold(query[cursor:start]))
+        prepared.append(_collapse_whitespace(query[cursor:start]))
         prepared.append(query[start:end])  # verbatim: a literal's case and spacing are data
         cursor = end
-    prepared.append(_fold(query[cursor:]))
+    prepared.append(_collapse_whitespace(query[cursor:]))
     return "".join(prepared).strip()
 
 
-def _fold(text: str) -> str:
-    return re.sub(r"\s+", " ", text.lower())
+def _collapse_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
 
 
 def _build_parsed_query(data: pd.DataFrame, query: str) -> ParsedQuery:

--- a/src/esql/parser/types.py
+++ b/src/esql/parser/types.py
@@ -25,6 +25,20 @@ class AggregatesDict(TypedDict):
     group_specific: list[GroupAggregate]
 
 
+def aggregate_key(aggregate: GlobalAggregate | GroupAggregate) -> str:
+    """How an aggregate is spelled as a key: `column.function`, or `group.column.function`.
+
+    The parser writes these into `select_items_in_order`, `GroupedRow` keys its data map by them and
+    the HAVING evaluator looks one up, so all three have to agree exactly or a projected column
+    silently comes back empty. It used to be three f-strings that happened to match, which held only
+    because the whole query was lowercased before parsing; now that identifiers carry the frame's
+    spelling, they have to be built from the same parts by the same code.
+    """
+    if "group" in aggregate:
+        return f"{aggregate['group']}.{aggregate['column']}.{aggregate['function']}"
+    return f"{aggregate['column']}.{aggregate['function']}"
+
+
 class LogicalOperator(Enum):
     AND = "and"
     OR = "or"

--- a/src/esql/parser/util.py
+++ b/src/esql/parser/util.py
@@ -27,6 +27,7 @@ from esql.parser.types import (
     SemiJoinCondition,
     SimpleCondition,
     SimpleGroupCondition,
+    aggregate_key,
 )
 
 ###########################################################################
@@ -84,6 +85,67 @@ DATE_PATTERN = re.compile(r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}$")
 
 
 ###########################################################################
+# Identifier Resolution
+###########################################################################
+# ESQL identifiers are case-insensitive; a DataFrame's column names are not. Every column and group
+# reference in a query therefore resolves through one of the two functions below, which answer with
+# the *canonical* spelling - the frame's for a column, the OVER clause's for a group - and the
+# parsed query carries that rather than what was typed. Execution indexes rows by the frame's
+# spelling (`execute.column_indices`), so anything else puts the column out of reach.
+#
+# That is exactly what it was until v1.9.0: `_prepare_query` lowercased the whole query before the
+# parser knew which words were identifiers, and resolution was a plain `in column_dtypes` against
+# the frame's real keys, so a frame with a `Cust` column could not be queried in any spelling and
+# the error blamed `'cust'`, a word the query never contained. See `.claude/status.md`, K1.
+
+
+def _resolve_column(name: str, column_dtypes: dict[str, np.dtype], error_type: ParsingErrorType) -> str | None:
+    """The frame's spelling of the column `name` names, or None when it names no column.
+
+    None means "not a column", which several callers need as an answer rather than an error: it is
+    how a bare word falls through to being read as a literal.
+
+    An exact match wins before a case-folded one, so a frame holding both `Cust` and `cust` is still
+    queryable by writing either exactly. Only a reference matching neither exactly and both when
+    folded is ambiguous, and that raises rather than silently picking one.
+    """
+    if name in column_dtypes:
+        return name
+    matches = [column for column in column_dtypes if str(column).lower() == name.lower()]
+    if len(matches) == 1:
+        return matches[0]
+    if matches:
+        raise ParsingError(
+            error_type,
+            f"'{name}' matches more than one column ({', '.join(sorted(str(m) for m in matches))}), "
+            f"so which one it means is ambiguous. Write one of them exactly.",
+            token=name,
+        )
+    return None
+
+
+def _resolve_group(name: str, groups: list[str]) -> str | None:
+    """The OVER clause's spelling of the group `name` names, or None when it names no group.
+
+    There is no ambiguous case to handle: `parse_over_clause` rejects two group names that differ
+    only in case, so a folded name matches at most one declared group.
+    """
+    for group in groups:
+        if group.lower() == name.lower():
+            return group
+    return None
+
+
+def _names_group(text: str, group: str) -> bool:
+    """Whether `text` opens with `<group>.`, case-insensitively.
+
+    Case folding preserves length, so a caller that gets True can slice `len(group) + 1` characters
+    off `text` to reach what follows the prefix.
+    """
+    return text[: len(group) + 1].lower() == f"{group}.".lower()
+
+
+###########################################################################
 # Keyword & Clause Extraction
 ###########################################################################
 def get_keyword_clauses(query: str) -> dict[str, str | None]:
@@ -95,9 +157,11 @@ def get_keyword_clauses(query: str) -> dict[str, str | None]:
     masked = mask_literals(query)
 
     keyword_indices = []
-    for keyword in (kw.lower() for kw in keyword_clauses):
+    for keyword in keyword_clauses:
+        # Case-insensitively, since the query arrives spelled however it was written. Case folding
+        # preserves length, so an index found here is that index into `query` too.
         pattern = r"\b" + re.escape(keyword.strip()) + r"\b"
-        matches = list(re.finditer(pattern, masked))
+        matches = list(re.finditer(pattern, masked, re.IGNORECASE))
         if matches:
             keyword_indices.append(matches[0].start())
         else:
@@ -155,6 +219,16 @@ def parse_over_clause(over_clause: str | None) -> list[str]:
         match = re.match(pattern, group)
         if not match:
             raise ParsingError(ParsingErrorType.OVER_CLAUSE, f"Invalid group name: '{group}'", token=group)
+        # Group names are case-insensitive like every other identifier, so two that differ only in
+        # case name the same group twice and a reference to either could not be resolved to one of
+        # them. This is what lets `_resolve_group` answer without an ambiguous case.
+        if existing := _resolve_group(group, groups):
+            raise ParsingError(
+                ParsingErrorType.OVER_CLAUSE,
+                f"Group '{group}' is already declared as '{existing}'; group names are "
+                f"case-insensitive, so these name the same group.",
+                token=group,
+            )
         groups.append(group)
     return groups
 
@@ -178,12 +252,15 @@ def parse_select_clause(
                 aggregates["group_specific"].append(aggregate_result)
             else:
                 aggregates["global_scope"].append(aggregate_result)
+            # The canonical key rather than what was written: these are looked up in the grouped
+            # row's data map, which is keyed the same way. See `types.aggregate_key`.
+            select_items_in_order.append(aggregate_key(aggregate_result))
         else:
-            if item in column_dtypes:
-                grouping_attributes.append(item)
-            else:
+            column = _resolve_column(item, column_dtypes, ParsingErrorType.SELECT_CLAUSE)
+            if column is None:
                 raise ParsingError(ParsingErrorType.SELECT_CLAUSE, f"Invalid column: '{item}'", token=item)
-        select_items_in_order.append(item)
+            grouping_attributes.append(column)
+            select_items_in_order.append(column)
     if len(grouping_attributes) == 0:
         raise ParsingError(
             ParsingErrorType.SELECT_CLAUSE, f"No grouping attributes given: '{select_clause}'", token=select_clause
@@ -243,7 +320,8 @@ def _parse_semi_join_condition(
             f"{SEMI_JOIN_OPERATOR} needs a column before it: '{condition}'",
             token=condition,
         )
-    if key not in column_dtypes:
+    resolved_key = _resolve_column(key, column_dtypes, ParsingErrorType.WHERE_CLAUSE)
+    if resolved_key is None:
         raise ParsingError(ParsingErrorType.WHERE_CLAUSE, f"Invalid column: {key}", token=key)
     if not inner:
         raise ParsingError(
@@ -252,7 +330,7 @@ def _parse_semi_join_condition(
             token=condition,
         )
     return SemiJoinCondition(
-        key=key, operator=SEMI_JOIN_OPERATOR, condition=_parse_where_clause(inner, column_dtypes)
+        key=resolved_key, operator=SEMI_JOIN_OPERATOR, condition=_parse_where_clause(inner, column_dtypes)
     )
 
 
@@ -260,21 +338,23 @@ def _parse_simple_condition(condition: str, column_dtypes: dict[str, np.dtype]) 
     condition = condition.strip()
     split = _split_condition(condition)
     if not split:
-        if condition in column_dtypes and pd.api.types.is_bool_dtype(column_dtypes[condition]):
-            return SimpleCondition(column=condition, operator="=", value=True, is_emf=False)
+        bare = _resolve_column(condition, column_dtypes, ParsingErrorType.WHERE_CLAUSE)
+        if bare is not None and pd.api.types.is_bool_dtype(column_dtypes[bare]):
+            return SimpleCondition(column=bare, operator="=", value=True, is_emf=False)
         raise ParsingError(
             ParsingErrorType.WHERE_CLAUSE, f"No conditional operator found in condition: '{condition}'", token=condition
         )
 
-    column, operator, value = split
-    if column not in column_dtypes:
-        raise ParsingError(ParsingErrorType.WHERE_CLAUSE, f"Invalid column: {column}", token=column)
+    written_column, operator, value = split
+    column = _resolve_column(written_column, column_dtypes, ParsingErrorType.WHERE_CLAUSE)
+    if column is None:
+        raise ParsingError(ParsingErrorType.WHERE_CLAUSE, f"Invalid column: {written_column}", token=written_column)
     if operator and value == "":
         raise ParsingError(ParsingErrorType.WHERE_CLAUSE, f"Missing value for condition: {condition}", token=condition)
 
     # An entry value reads the grouped row being computed, and WHERE runs before there are any, so
     # it is rejected here by name rather than falling through to "invalid value".
-    entry_value = _parse_entry_value(value, column_dtypes)
+    entry_value = _parse_entry_value(value, column_dtypes, ParsingErrorType.WHERE_CLAUSE)
     if entry_value:
         raise ParsingError(
             ParsingErrorType.WHERE_CLAUSE,
@@ -385,7 +465,7 @@ def _parse_such_that_section(
 
     group_found = None
     for group in groups:
-        if section.startswith(group + "."):
+        if _names_group(section, group):
             group_found = group
             break
     if not group_found:
@@ -393,7 +473,7 @@ def _parse_such_that_section(
             ParsingErrorType.SUCH_THAT_CLAUSE, f"No valid group found in condition: '{section}'", token=section
         )
 
-    if any(other_group + "." in section for other_group in groups if other_group != group_found):
+    if any(f"{other}.".lower() in section.lower() for other in groups if other != group_found):
         raise ParsingError(
             ParsingErrorType.SUCH_THAT_CLAUSE,
             f"Multiple groups found in a clause: '{section}'\nEach comma separated clause must contain only one group.",
@@ -416,20 +496,24 @@ def _parse_simple_group_condition(
         )
     split = _split_condition(condition)
     if not split:
-        if condition.startswith(group + "."):
-            column = condition[len(group) + 1 :].strip()
-            if column in column_dtypes and pd.api.types.is_bool_dtype(column_dtypes[column]):
-                return SimpleGroupCondition(group=group, column=column, operator="=", value=True, is_emf=False)
+        if _names_group(condition, group):
+            written_column = condition[len(group) + 1 :].strip()
+            bare = _resolve_column(written_column, column_dtypes, ParsingErrorType.SUCH_THAT_CLAUSE)
+            if bare is not None and pd.api.types.is_bool_dtype(column_dtypes[bare]):
+                return SimpleGroupCondition(group=group, column=bare, operator="=", value=True, is_emf=False)
         raise ParsingError(ParsingErrorType.SUCH_THAT_CLAUSE, f"Invalid condition: '{condition}'", token=condition)
 
     left, operator, value = split
-    if not left.startswith(group + "."):
+    if not _names_group(left, group):
         raise ParsingError(
             ParsingErrorType.SUCH_THAT_CLAUSE, f"Invalid group for condition: '{condition}'", token=condition
         )
-    column = left[len(group) + 1 :]
-    if column not in column_dtypes:
-        raise ParsingError(ParsingErrorType.SUCH_THAT_CLAUSE, f"Invalid column: '{column}'", token=column)
+    written_column = left[len(group) + 1 :]
+    column = _resolve_column(written_column, column_dtypes, ParsingErrorType.SUCH_THAT_CLAUSE)
+    if column is None:
+        raise ParsingError(
+            ParsingErrorType.SUCH_THAT_CLAUSE, f"Invalid column: '{written_column}'", token=written_column
+        )
     if operator and value == "":
         raise ParsingError(
             ParsingErrorType.SUCH_THAT_CLAUSE, f"Missing value for condition: {condition}", token=condition
@@ -437,7 +521,7 @@ def _parse_simple_group_condition(
 
     # An entry value makes this an EMF condition: what it compares against is not known until
     # execution reaches an output row, so parsing stops at the reference and validates it.
-    entry_value = _parse_entry_value(value, column_dtypes)
+    entry_value = _parse_entry_value(value, column_dtypes, ParsingErrorType.SUCH_THAT_CLAUSE)
     if entry_value:
         _validate_entry_value(
             entry_value=entry_value,
@@ -577,14 +661,16 @@ def _parse_aggregate(
     aggregate: str,
     groups: list[str],
     column_dtypes: dict[str, np.dtype],
-    error_type=ParsingErrorType.SELECT_CLAUSE or ParsingErrorType.HAVING_CLAUSE,
+    error_type: ParsingErrorType,
 ) -> GlobalAggregate | GroupAggregate:
     parts = aggregate.split(".")
 
     # Format: column.aggregate_function
     if len(parts) == 2:
-        column, func = parts
-        if column not in column_dtypes:
+        written_column, func = parts
+        column = _resolve_column(written_column, column_dtypes, error_type)
+        func = func.lower()
+        if column is None:
             raise ParsingError(error_type, f"Invalid aggregate column: '{aggregate}'", token=aggregate)
         elif func not in AGGREGATE_FUNCTIONS:
             raise ParsingError(error_type, f"Invalid aggregate function: '{aggregate}'", token=aggregate)
@@ -598,10 +684,13 @@ def _parse_aggregate(
 
     # Format: group.column.aggregate_function
     elif len(parts) == 3:
-        group, column, func = parts
-        if group not in groups:
+        written_group, written_column, func = parts
+        group = _resolve_group(written_group, groups)
+        column = _resolve_column(written_column, column_dtypes, error_type)
+        func = func.lower()
+        if group is None:
             raise ParsingError(error_type, f"Invalid aggregate group: '{aggregate}'", token=aggregate)
-        elif column not in column_dtypes:
+        elif column is None:
             raise ParsingError(error_type, f"Invalid aggregate column: '{aggregate}'", token=aggregate)
         elif func not in AGGREGATE_FUNCTIONS:
             raise ParsingError(error_type, f"Invalid aggregate function: '{aggregate}'", token=aggregate)
@@ -626,7 +715,7 @@ def _parse_condition_value(
     operator: str,
     value: str,
     condition: str,
-    error_type=ParsingErrorType.SELECT_CLAUSE or ParsingErrorType.SUCH_THAT_CLAUSE,
+    error_type: ParsingErrorType,
 ) -> float | bool | str | date:
     value = value.strip()
 
@@ -685,7 +774,9 @@ def _parse_condition_value(
 ###########################################################################
 # Entry Value Parsing
 ###########################################################################
-def _parse_entry_value(value: str, column_dtypes: dict[str, np.dtype]) -> EntryValue | None:
+def _parse_entry_value(
+    value: str, column_dtypes: dict[str, np.dtype], error_type: ParsingErrorType
+) -> EntryValue | None:
     """Read `value` as `<column>` or `<column> ± <number>`, or None when it is not that shape.
 
     None means "this is a literal, not a column reference", so a caller falls through to the
@@ -698,8 +789,9 @@ def _parse_entry_value(value: str, column_dtypes: dict[str, np.dtype]) -> EntryV
     match = ENTRY_VALUE_PATTERN.match(value.strip())
     if not match:
         return None
-    attribute, sign, offset = match.groups()
-    if attribute not in column_dtypes:
+    written_attribute, sign, offset = match.groups()
+    attribute = _resolve_column(written_attribute, column_dtypes, error_type)
+    if attribute is None:
         return None
     if offset is None:
         return EntryValue(attribute=attribute, delta=0)
@@ -870,8 +962,9 @@ def _operator_starts_at(condition: str, index: int, operator: str) -> bool:
 
     A word operator (CONTAINS) has to sit on word boundaries, or a column named `contains_tax`
     would split as the operator. A symbol operator (>=) cannot collide that way and matches
-    directly. The comparison is case-insensitive because `_prepare_query` lowercases everything
-    outside quotes, so the canonical uppercase spelling is what callers see back.
+    directly. The comparison folds case, which is where operator case-insensitivity lives now that
+    `_prepare_query` no longer lowercases the query; callers get the canonical spelling back either
+    way, since what is returned is the constant rather than the matched text.
     """
     candidate = condition[index : index + len(operator)]
     if not operator.isalpha():

--- a/tests/accessor/test_validate.py
+++ b/tests/accessor/test_validate.py
@@ -43,12 +43,16 @@ def test_validate_reports_the_offending_token(sales_test_data, query, error_type
     assert excinfo.value.token == token
 
 
-def test_token_matches_the_query_case_insensitively(sales_test_data):
-    """The parser lowercases outside quotes, so the token comes back lowered — an editor looking
-    for it in what the user actually typed has to fold case."""
+def test_token_is_spelled_as_the_query_spelled_it(sales_test_data):
+    """The token comes back exactly as written, so an editor can find it in what the user typed.
+
+    It used to come back lowercased, because the parser ran on a lowercased copy of the query. That
+    is the same fold that made a mixed-case column unreachable (K1); now that it is gone, a token
+    matches literally rather than only case-insensitively.
+    """
     with pytest.raises(ParsingError) as excinfo:
         sales_test_data.esql.validate("SELECT cust, QUANTT.avg")
-    assert excinfo.value.token == "quantt.avg"
+    assert excinfo.value.token == "QUANTT.avg"
 
 
 def test_group_prefixed_aggregate_without_over_is_a_parsing_error(sales_test_data):

--- a/tests/parser/test_identifier_case.py
+++ b/tests/parser/test_identifier_case.py
@@ -1,0 +1,198 @@
+"""Identifiers are case-insensitive, and a mixed-case DataFrame column is reachable.
+
+Regression cover for `.claude/status.md`, K1. `_prepare_query` used to lowercase the whole query
+outside its string literals, and column resolution was then a plain `in column_dtypes` against the
+frame's real, case-carrying keys. A frame whose columns were `Cust` and `Quant` was therefore
+unqueryable in *every* spelling — `Cust`, `cust` and `CUST` all failed with
+`Invalid column: 'cust'`, naming a word the query never contained — and nothing in the repo or the
+demo noticed, because `sales.csv` and both portfolio datasets are lowercase throughout.
+
+The fix moves case folding out of the query string and into the places that know the structure: the
+keyword and operator matches fold case themselves, and every column and group reference goes
+through `_resolve_column` / `_resolve_group`, which answer with the *canonical* spelling — the
+frame's for a column, the OVER clause's for a group. What the parser hands execution is therefore
+always something `execute`'s `column_indices` can index by.
+
+The tests below are written against a frame that is mixed-case throughout, since that is the case
+that used to be unreachable, and they check both halves: that the query works whatever it writes,
+and that what comes back is labelled canonically.
+"""
+
+import inspect
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from esql.accessor import _enforce_allowed_dtypes
+from esql.parser.error import ParsingError, ParsingErrorType
+from esql.parser.util import _parse_aggregate, _parse_condition_value
+
+
+@pytest.fixture
+def mixed_case_data() -> pd.DataFrame:
+    """A frame spelled the way a caller's own frame usually is, rather than all lowercase."""
+    return _enforce_allowed_dtypes(
+        pd.DataFrame(
+            {
+                "Cust": ["Dan", "Dan", "Dan", "Emily", "Emily"],
+                "Prod": ["Ham", "Butter", "Ham", "Ham", "Cherry"],
+                "Quant": [10, 20, 30, 40, 50],
+                "Month": [1, 2, 3, 1, 2],
+                "SaleDate": ["2020-01-15", "2020-02-15", "2020-03-15", "2020-01-20", "2020-02-20"],
+                "OnCredit": [True, False, True, True, False],
+            }
+        )
+    )
+
+
+###########################################################################
+# The K1 case itself
+###########################################################################
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT Cust, Quant.sum",  # the frame's own spelling
+        "SELECT cust, quant.sum",  # all lowercase
+        "SELECT CUST, QUANT.SUM",  # all uppercase
+        "SELECT cUsT, QuAnT.SuM",  # neither
+    ],
+)
+def test_a_mixed_case_column_is_reachable_in_any_spelling(mixed_case_data, query):
+    """The bug: all four of these raised `Invalid column: 'cust'`."""
+    result = mixed_case_data.esql.query(query)
+    assert result.to_dict("records") == [
+        {"Cust": "Dan", "Quant.sum": 60},
+        {"Cust": "Emily", "Quant.sum": 90},
+    ]
+
+
+def test_the_result_is_labelled_with_the_frames_spelling(mixed_case_data):
+    """Not the query's, so the labels are the same whatever the query wrote.
+
+    This is what forces the parser to resolve rather than pass the written name through: the label
+    is also the key execution looks the value up by (`types.aggregate_key`), so a query-spelled
+    label would find nothing in the grouped row's data map.
+    """
+    lowercased = mixed_case_data.esql.query("SELECT cust, month, quant.avg")
+    shouted = mixed_case_data.esql.query("SELECT CUST, MONTH, QUANT.AVG")
+    assert list(lowercased.columns) == ["Cust", "Month", "Quant.avg"]
+    assert list(shouted.columns) == ["Cust", "Month", "Quant.avg"]
+
+
+###########################################################################
+# The rest of the language, on the same frame
+###########################################################################
+def test_keywords_are_case_insensitive(mixed_case_data):
+    result = mixed_case_data.esql.query("select Cust, Quant.sum WHERE Prod = 'Ham' Having Quant.sum > 20 order BY 1")
+    assert result.to_dict("records") == [{"Cust": "Dan", "Quant.sum": 40}, {"Cust": "Emily", "Quant.sum": 40}]
+
+
+def test_a_group_is_referenced_case_insensitively_and_labelled_as_over_declared_it(mixed_case_data):
+    """A group's canonical spelling is the OVER clause's, since that is where it is declared."""
+    result = mixed_case_data.esql.query("SELECT Cust, G1.Quant.sum OVER G1 SUCH THAT g1.MONTH = 1")
+    assert result.to_dict("records") == [{"Cust": "Dan", "G1.Quant.sum": 10}, {"Cust": "Emily", "G1.Quant.sum": 40}]
+
+
+def test_two_group_names_differing_only_in_case_are_rejected(mixed_case_data):
+    """They name the same group, so a reference to either could not resolve to one of them. This is
+    what leaves `_resolve_group` with no ambiguous case to answer."""
+    with pytest.raises(ParsingError) as excinfo:
+        mixed_case_data.esql.validate("SELECT Cust, g1.Quant.sum OVER G1, g1 SUCH THAT g1.Month = 1")
+    assert excinfo.value.error_type is ParsingErrorType.OVER_CLAUSE
+    assert excinfo.value.token == "g1"
+
+
+def test_an_entry_value_attribute_is_case_insensitive(mixed_case_data):
+    """The EMF case: `_parse_entry_value` resolves the attribute it names, and `_validate_entry_value`
+    then checks the resolved name against the SELECT grouping attributes, which are resolved too."""
+    result = mixed_case_data.esql.query(
+        "SELECT Cust, Month, PREV.Quant.sum OVER prev SUCH THAT prev.CUST = cust and prev.MONTH = month - 1"
+    )
+    dans = result[result["Cust"] == "Dan"].sort_values("Month")
+    assert list(dans["Month"]) == [1, 2, 3]
+    assert pd.isna(dans["prev.Quant.sum"].iloc[0])  # no month 0, so nothing to roll up
+    assert list(dans["prev.Quant.sum"].iloc[1:]) == [10, 20]
+
+
+def test_a_semi_join_key_is_case_insensitive(mixed_case_data):
+    result = mixed_case_data.esql.query("SELECT Cust, Quant.sum WHERE CUST HAS prod = 'Butter'")
+    assert result.to_dict("records") == [{"Cust": "Dan", "Quant.sum": 60}]
+
+
+def test_an_aggregate_named_in_both_select_and_having_is_still_one_aggregate(mixed_case_data):
+    """Written in different cases in the two clauses, it must still dedup to one.
+
+    The merge in `_build_parsed_query` compares parsed aggregates, so both have to canonicalize the
+    same way. If they did not, the aggregate would be accumulated twice per row and the sum would
+    silently double, which is BUG-8 from v1.1 arriving by a different route.
+    """
+    result = mixed_case_data.esql.query("SELECT cust, QUANT.SUM HAVING quant.sum > 70")
+    assert result.to_dict("records") == [{"Cust": "Emily", "Quant.sum": 90}]
+
+
+def test_a_bare_boolean_column_is_case_insensitive_in_where_and_such_that(mixed_case_data):
+    where = mixed_case_data.esql.query("SELECT Cust, Quant.sum WHERE ONCREDIT")
+    such_that = mixed_case_data.esql.query("SELECT Cust, g1.Quant.sum OVER g1 SUCH THAT G1.oncredit")
+    assert where.to_dict("records") == [{"Cust": "Dan", "Quant.sum": 40}, {"Cust": "Emily", "Quant.sum": 40}]
+    assert such_that.to_dict("records") == [
+        {"Cust": "Dan", "g1.Quant.sum": 40},
+        {"Cust": "Emily", "g1.Quant.sum": 40},
+    ]
+
+
+def test_contains_and_a_date_comparison_resolve_their_columns_too(mixed_case_data):
+    """The two condition values that are not plain numbers, so they take their own branches in
+    `_parse_condition_value` and read the resolved column's dtype rather than the written name's."""
+    contains = mixed_case_data.esql.query("SELECT Cust, Quant.sum WHERE PROD CONTAINS 'err'")
+    dates = mixed_case_data.esql.query("SELECT Cust, SALEDATE WHERE saledate > '2020-03-01'")
+    assert contains.to_dict("records") == [{"Cust": "Emily", "Quant.sum": 50}]
+    assert dates.to_dict("records") == [{"Cust": "Dan", "SaleDate": date(2020, 3, 15)}]
+
+
+###########################################################################
+# What is *not* case-insensitive
+###########################################################################
+def test_a_literals_case_is_data_and_is_not_folded(mixed_case_data):
+    """The other half of the same pass: outside a literal case is a spelling, inside it is a value.
+
+    `=` is case-sensitive by design (v1.3.0), so folding a literal here would silently widen every
+    equality comparison in the language.
+    """
+    assert mixed_case_data.esql.query("SELECT Cust WHERE Prod = 'Ham'").to_dict("records") == [
+        {"Cust": "Dan"},
+        {"Cust": "Emily"},
+    ]
+    assert mixed_case_data.esql.query("SELECT Cust WHERE Prod = 'HAM'").empty
+
+
+def test_a_reference_matching_two_columns_when_folded_is_ambiguous():
+    """A frame *can* hold `Cust` and `cust` at once, and then a folded reference has two answers.
+
+    Resolution tries an exact match first, so both columns stay reachable by writing either exactly.
+    Only a third spelling is ambiguous, and that raises rather than picking one.
+    """
+    data = _enforce_allowed_dtypes(pd.DataFrame({"Cust": ["Dan"], "cust": ["dan"], "Quant": [1]}))
+
+    assert data.esql.query("SELECT Cust").to_dict("records") == [{"Cust": "Dan"}]
+    assert data.esql.query("SELECT cust").to_dict("records") == [{"cust": "dan"}]
+
+    with pytest.raises(ParsingError) as excinfo:
+        data.esql.validate("SELECT CUST")
+    assert excinfo.value.error_type is ParsingErrorType.SELECT_CLAUSE
+    assert excinfo.value.token == "CUST"
+    assert "ambiguous" in excinfo.value.message
+
+
+###########################################################################
+# K2
+###########################################################################
+@pytest.mark.parametrize("function", [_parse_aggregate, _parse_condition_value])
+def test_error_type_is_a_required_argument(function):
+    """K2. Both of these used to default it to `A or B`, which is `A` for any truthy `A`, so the
+    second clause name had never meant anything. Every call site passes one explicitly, which is why
+    it was harmless and why it had to go: it read as if it selected a clause per caller, sitting in
+    the code that reports which clause rejected a value. Required, so a future caller cannot
+    silently inherit `SELECT CLAUSE` for a WHERE failure.
+    """
+    assert inspect.signature(function).parameters["error_type"].default is inspect.Parameter.empty

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -19,9 +19,15 @@ from esql.parser.types import (
 )
 
 
-def test_prepare_query_returns_expected_structure():
+def test_prepare_query_collapses_whitespace_and_changes_nothing_else():
+    """Whitespace outside a literal is formatting; everything else, case included, is left alone.
+
+    It used to lowercase the query here as well. That is what put a mixed-case DataFrame column out
+    of reach in every spelling (`.claude/status.md`, K1): folding ran before the parser knew which
+    words were identifiers, so `SELECT Cust` asked the frame for `cust`.
+    """
     query = 'SELECT cust,         prod,         g1.quant.sum OVER g1,g2,g3      WHERE cust = "DAN" and month = 1 or prod =   "APLEHSVCDGhsfjadmg_hgdoe3v¡=3h8d" Such thAt g3.prod = \'bceL;lwhan\',g2.state="NY" HAvING g1.quant.avg > 0.5 orDer by     3'
-    expected = 'select cust, prod, g1.quant.sum over g1,g2,g3 where cust = "DAN" and month = 1 or prod = "APLEHSVCDGhsfjadmg_hgdoe3v¡=3h8d" such that g3.prod = \'bceL;lwhan\',g2.state="NY" having g1.quant.avg > 0.5 order by 3'
+    expected = 'SELECT cust, prod, g1.quant.sum OVER g1,g2,g3 WHERE cust = "DAN" and month = 1 or prod = "APLEHSVCDGhsfjadmg_hgdoe3v¡=3h8d" Such thAt g3.prod = \'bceL;lwhan\',g2.state="NY" HAvING g1.quant.avg > 0.5 orDer by 3'
     result = _prepare_query(query)
     assert result == expected
 

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
Closes Stream K. `make check` green at **247 tests** (was 230); mypy 157 (was 159).

## K1 — a mixed-case DataFrame column was unreachable in every spelling

```python
df = pd.DataFrame({"Cust": [...], "Quant": [...]})
df.esql.query("SELECT Cust, Quant.sum")   # -> [SELECT CLAUSE] Invalid column: 'cust'
df.esql.query("SELECT cust, quant.sum")   # -> [SELECT CLAUSE] Invalid column: 'cust'
df.esql.query("SELECT CUST, QUANT.SUM")   # -> [SELECT CLAUSE] Invalid column: 'cust'
```

`_prepare_query` lowercased the query before the parser knew which words were identifiers, and resolution was then a plain `in column_dtypes` against the frame's real, case-carrying keys. Nothing in the repo or the demo hit it, because `sales.csv` and both portfolio datasets are lowercase throughout. It bit the first person to point the accessor at their own frame, which is the entire published use.

**The fix is a deletion.** The fold is gone; `_prepare_query` rewrites only whitespace. That also closes the failure mode J4 and K1 shared: a rule applied by rewriting the query string before its structure is known.

Four of the six things the fold appeared to be doing already folded case on their own (`_operator_starts_at`, the AND/OR split, the NOT prefix, the `true`/`false` literals), which is why the change is small. The two that did not:

- `get_keyword_clauses` searches with `re.IGNORECASE`.
- Every column and group reference goes through `_resolve_column` / `_resolve_group`, which answer with the **canonical** spelling: the frame's for a column, `OVER`'s for a group. That is what makes this a fix rather than a relocation, since `execute` indexes rows by the frame's spelling.

### Three things that fell out, not in the filing

| | |
|---|---|
| Aggregate functions had to canonicalize too | the SELECT/HAVING dedup compares parsed aggregates, so without it `SELECT quant.sum HAVING QUANT.SUM > 0` accumulates twice per row and **silently doubles the sum** — BUG-8 from v1.1 by a new route |
| `aggregate_key` had three homes | parser select items, `GroupedRow`, HAVING evaluator, agreeing only because everything was lowercase. One function in `parser/types.py` now; a mismatch is silent, the column comes back empty |
| `OVER g1, g1` parsed and meant nothing | rejected, as part of rejecting two group names differing only in case |

### Decisions

- **Exact match before folded**, so a frame holding both `Cust` and `cust` stays queryable by writing either. Only a third spelling (`CUST`) is ambiguous, and that raises naming both candidates. Rejecting such a frame up front refuses queries that have one obvious answer.
- **Results are labelled canonically**, not as the query wrote them: `SELECT CUST, QUANT.SUM` returns `Cust` and `Quant.sum`. The label is also the data-map key, so canonical keeps the two in step by construction rather than by both being lowercase.
- **`ParsingError.token` is now literal.** It used to come back lowercased and `README.md` told consumers to fold case. Contract improvement; both README and the docstring were saying the old thing.

## K2

The two `error_type=ParsingErrorType.A or ParsingErrorType.B` defaults are deleted and the parameter is required. `A or B` is `A` for any truthy `A`, so the second name never meant anything — in the function that reports which clause rejected a value. `test_error_type_is_a_required_argument` pins it.

## Cover

`tests/parser/test_identifier_case.py`, 17 tests over a frame that is mixed-case throughout, plus the two existing tests that asserted the old behavior and were inverted. Verified the suite bites, by reverting each part of the fix in turn:

| reverted | tests failing |
|---|---|
| the lowercase fold restored | 4 |
| `_resolve_column` exact-only | 12 |
| `select_items_in_order` back to written text | 6 |
| `re.IGNORECASE` dropped | 13 |
| `_names_group` case-sensitive | 2 |

## Docs

`public/docs/syntax.md` claimed "ESQL is not case sensitive" and that claim was **false** for the entire published use. It has a **Case** section now — what is folded, what is not, what a result is labelled with — the OVER section names the collision rule, and `README.md` says it in the accessor walkthrough. Every example in both was run against the engine.

**Considered and declined: publishing the case rule in `GRAMMAR`.** No host needs it — a caret menu inserts canonical names off the dataset asset, and a host pre-checking a typed query calls `validate`, which now answers correctly. Same discipline G3 records: no surface before there is a reader.

## Consumer impact

**None required.** No new name in `esql.__all__`, no new slot kind, no new `GRAMMAR` key, so neither portfolio's export-diff guard nor its `unhandledSlotKinds` check fires. Both portfolio datasets are lowercase throughout, so every result label is byte-identical to 1.8.0. The one thing worth knowing is that `ParsingError.token` is now literal, which makes portfolio's existing case-insensitive match correct but no longer necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)