### PR TITLE
v1.10.0: decide value completions by dimensionality ratio, not one distinct count (J3)

### DIFF
--- a/.claude/status.md
+++ b/.claude/status.md
@@ -42,8 +42,8 @@ place of rules it used to hand-mirror.
 
 The counterpart to Stream G. G published what is *legal* (the grammar); this publishes the *shape*
 of what `demokit` writes, and the *data* a host needs to complete a value. J1 and J2 shipped in
-v1.7.0 (commit `5e6770d`, tagged and pushed) and J4 in v1.8.0. The gate is green at **229 tests**
-(was 162).
+v1.7.0 (commit `5e6770d`, tagged and pushed), J4 and J5 in v1.8.0, and J3 in v1.10.0, which closes
+the stream. The gate is green at **250 tests** (was 162).
 
 - [x] **J1. `dataset.schema.json`.** Shipped as `esql.DATASET_SCHEMA` (`src/esql/dataset_schema.py`):
   the `<id>.json` asset declared as JSON Schema. `build_demo` validates its output dict against it
@@ -76,7 +76,7 @@ v1.7.0 (commit `5e6770d`, tagged and pushed) and J4 in v1.8.0. The gate is green
   It lives here rather than in portfolio's `backend/esql/` because `build_demo` composes the whole
   output dict — a dataset's `demo.py` only hands it a spec.
 
-- [ ] **J3. The cap is set almost exactly wrong, and is probably the wrong instrument.** Filed from
+- [x] **J3. The cap is set almost exactly wrong, and is probably the wrong instrument.** Filed from
   portfolio 2026-07-29 after wiring J2 into the editor. The Grateful Dead dataset has **520** distinct
   venues against `DISTINCT_VALUE_CAP = 500`, so `venue` ships nothing and `WHERE venue = '` offers
   nothing — the one column where a visitor most needs help spelling (`Magoo's Pizza Parlor`). Missing
@@ -90,6 +90,10 @@ v1.7.0 (commit `5e6770d`, tagged and pushed) and J4 in v1.8.0. The gate is green
   generous absolute ceiling for asset-size safety, rather than one count doing both jobs badly.
 
   Either fix unblocks portfolio. The ratio version is the one worth having.
+
+  **Shipped in v1.10.0**, the ratio version. See that entry in the settled record: the count could
+  not have been raised to admit venue without also admitting `quant`, so the cheap fix was not
+  available even as a stopgap.
 
 - [x] **J4. A quote inside a same-quoted literal parses and then matches nothing.** Shipped in
   v1.8.0; see that entry in the settled record. Both candidate fixes were taken, doubling *and*
@@ -756,6 +760,46 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   still the better default, since a delimiter swap reads better than a doubled quote. What changes
   is that it no longer has to be the *only* answer, and a visitor typing the apostrophe form by hand
   now gets an error telling them what to do instead of a confident empty table.
+
+## v1.10.0 — value completions are decided by ratio, not by one count (2026-07-29)
+
+- [x] **J3.** `demokit` now asks "is this column a dimension?" rather than "does it have few enough
+  values?". Bumped `1.9.0 -> 1.10.0`; the gate is green at **250 tests** (was 247).
+
+  Three constants, because the old single count was answering three questions at once and getting two
+  of them wrong:
+
+  - **`DIMENSION_RATIO = 0.05`** — distinct values as a share of rows. This is the real test, since a
+    dimension sits far below its row count and a measure or free-text column climbs toward 100%.
+  - **`SMALL_VALUE_SET = 50`** — ships regardless of ratio. A ratio says nothing on a small frame
+    (four states over fifty rows is 8%), and any set this small is worth scrolling anyway. Without it
+    the fix would have broken small demo datasets to fix a large one.
+  - **`DISTINCT_VALUE_CAP = 2000`** — asset size only, not usefulness. 5% of a million-row frame is
+    50,000 values, so the ceiling has to stay.
+
+  **5% is not an arbitrary pick: it is the only band that keeps every current decision.** Checked
+  against `sales.csv` column by column, and the new rule reproduces the old verdict on all nine
+  while admitting venue:
+
+  | column | distinct / rows | ratio | ships |
+  |---|---|---|---|
+  | `state` / `year` / `cust` / `prod` / `month` / `day` / `credit` | 2–31 / 10,000 | ≤0.3% | yes, as before |
+  | `quant` (a measure) | 1,000 / 10,000 | 10% | no, as before |
+  | `date` (near-unique) | 1,818 / 10,000 | 18% | no, as before |
+  | `venue` (the filed case) | 520 / 39,774 | 1.3% | **yes**, 6.5 KB of JSON |
+
+  That band matters in both directions. Raising the count to 1000 as the cheap fix would have
+  admitted `quant` at 10% — a thousand quantities nobody completes — so the count could not be set to
+  include venue without also including a measure. The ratio separates them by an order of magnitude.
+
+  **`values` in `DATASET_SCHEMA` no longer describes itself as capped**, since "within the build's
+  cap" is now only a third of the rule. It says the build judged the column a dimension by its
+  distinct count as a share of its rows, without naming the numbers: a published description that
+  carries a threshold is a second copy of it, and J5 is the standing lesson about prose nothing binds.
+
+  **Portfolio-side follow-up: rebuild, nothing to change.** No new name in `esql.__all__`, no
+  `GRAMMAR` key and no slot kind, so neither guard fires. The visible effect is that a build against
+  1.10.0 emits `values` for `venue`, and `WHERE venue = '` starts completing.
 
 ## 3. Engine-side prep for the ESQL demo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.9.0"
+version = "1.10.0"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/esql/dataset_schema.py
+++ b/src/esql/dataset_schema.py
@@ -118,8 +118,9 @@ DATASET_SCHEMA: dict[str, Any] = {
                     "type": "array",
                     "description": (
                         "The column's distinct values as text, for value completion in a host editor. "
-                        "Present only when the column is discrete and its distinct count is within the "
-                        "build's cap; absent means 'do not offer completions', not 'no values'. Text "
+                        "Present only when the column is discrete and the build judged it a dimension "
+                        "worth completing, by its distinct count as a share of its rows; absent means "
+                        "'do not offer completions', not 'no values'. Text "
                         "regardless of the column's type, and unquoted: it is the datum, not the "
                         "literal syntax, so a host quotes it according to `type`."
                     ),

--- a/src/esql/demokit.py
+++ b/src/esql/demokit.py
@@ -30,12 +30,25 @@ import esql.accessor  # noqa: F401  (registers the .esql accessor)
 from esql.accessor import _enforce_allowed_dtypes
 from esql.dataset_schema import DATASET_SCHEMA, DatasetSchemaError, validate_dataset
 
-# How many distinct values a column may hold and still ship them all. A host offers these as value
-# completions ("WHERE song = '" should suggest real song names), so the cap is about what is useful
-# to scroll and what is reasonable to ship, not about correctness -- above it the column is a poor
-# completion source anyway. Generous on purpose: the Grateful Dead archive's song column is a few
-# hundred titles and is exactly the case this exists for.
-DISTINCT_VALUE_CAP = 500
+# Whether a column ships its distinct values, for a host to offer as completions ("WHERE song = '"
+# should suggest real song names). The question is "does completing this column help?", and the
+# signal for that is the *ratio* of distinct values to rows: a dimension sits far below its row
+# count (the Grateful Dead archive's 520 venues over 39,774 rows, 1.3%) while a measure or a
+# free-text column climbs toward 100% and is useless to complete at any cardinality.
+#
+# A count alone did both jobs badly. At 500 it excluded that venue column by twenty, losing exactly
+# the values a visitor most needs help spelling, and raising the count until venue fit would have
+# started shipping `quant` (1,000 distinct over 10,000 rows), a measure nobody completes.
+DIMENSION_RATIO = 0.05
+
+# Below this, a column ships regardless of ratio. A ratio is meaningless on a small frame -- four
+# states over fifty rows is 8%, plainly a dimension -- and any set this small is worth scrolling.
+SMALL_VALUE_SET = 50
+
+# The absolute ceiling, for asset size rather than usefulness: 5% of a million-row frame would pass
+# the ratio test with 50,000 values and megabytes of JSON. 436 songs cost ~35 KB of a 60 KB asset,
+# so this is generous while the assets stay small.
+DISTINCT_VALUE_CAP = 2000
 
 
 def _friendly_type(series: pd.Series) -> str:
@@ -70,15 +83,19 @@ def _value_text(value) -> str:
 def _distinct_values(series: pd.Series, friendly_type: str) -> list[str] | None:
     """The column's distinct values as text, or None when it should not offer completions.
 
-    None for a continuous column and for one above `DISTINCT_VALUE_CAP`; an empty list only when the
-    column genuinely holds no non-null value. Floats are taken as the continuous case -- a measure
-    like a duration in seconds has no value worth completing, while discrete numbers (a month, a set
-    position) do and are integers.
+    None for a continuous column, for one whose distinct count is too high a share of its rows to be
+    a dimension (`DIMENSION_RATIO`, with `SMALL_VALUE_SET` as the small-frame escape), and for one
+    over `DISTINCT_VALUE_CAP` whatever its ratio; an empty list only when the column genuinely holds
+    no non-null value. Floats are taken as the continuous case -- a measure like a duration in
+    seconds has no value worth completing, while discrete numbers (a month, a set position) do and
+    are integers.
     """
     if friendly_type == "number" and pdt.is_float_dtype(series.dtype):
         return None
     uniques = pd.unique(series.dropna())
     if len(uniques) > DISTINCT_VALUE_CAP:
+        return None
+    if len(uniques) > max(SMALL_VALUE_SET, DIMENSION_RATIO * len(series)):
         return None
     texts = [_value_text(v) for v in uniques]
     # Numbers sort numerically rather than as text, so a month list reads 1,2,...,10 not 1,10,11,2.

--- a/tests/test_demokit.py
+++ b/tests/test_demokit.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pytest
 
 from esql.dataset_schema import DATASET_SCHEMA, validate_dataset
-from esql.demokit import DISTINCT_VALUE_CAP, _distinct_values, _schema, build_demo
+from esql.demokit import DIMENSION_RATIO, DISTINCT_VALUE_CAP, _distinct_values, _schema, build_demo
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SALES_CSV = REPO_ROOT / "public" / "data" / "sales.csv"
@@ -93,7 +93,7 @@ def test_an_example_whose_sql_disagrees_still_fails_first(tmp_path):
 
 
 # --------------------------------------------------------------------------------------------
-# Capped distinct values -- the value-completion payload.
+# Distinct values -- the value-completion payload, and which columns earn one.
 # --------------------------------------------------------------------------------------------
 
 
@@ -117,21 +117,48 @@ def test_a_discrete_numeric_column_ships_values_sorted_numerically(built):
     assert month["values"] == [str(n) for n in range(1, 13)]
 
 
-def test_a_column_over_the_cap_ships_no_values(built):
-    """`date` holds 1818 distinct values, well past the cap, so it offers no completions at all --
-    which is different from offering none because it has none."""
+def test_a_column_too_distinct_to_be_a_dimension_ships_no_values(built):
+    """`quant` is a measure (1000 distinct over 10,000 rows, 10%) and `date` is near-unique per row
+    (1818, 18%). Both are above `DIMENSION_RATIO`, so neither offers completions at all -- which is
+    different from offering none because it has none."""
     assert "values" not in _column(built["asset"], "date")
     assert "values" not in _column(built["asset"], "quant")
 
 
-def test_a_continuous_column_ships_no_values_even_under_the_cap():
+def test_a_continuous_column_ships_no_values_even_when_discrete_enough():
     series = pd.Series([1.5, 2.5, 1.5], name="duration")
     assert _distinct_values(series, "number") is None
 
 
-def test_the_cap_is_a_ceiling_not_a_truncation():
-    under = pd.Series(range(DISTINCT_VALUE_CAP), dtype="int64")
-    over = pd.Series(range(DISTINCT_VALUE_CAP + 1), dtype="int64")
+def test_a_dimension_ships_its_values_however_many_it_has():
+    """The case the count got wrong: 520 venues over 39,774 rows is 1.3%, plainly a dimension, and
+    was excluded by twenty under `DISTINCT_VALUE_CAP = 500`."""
+    venues = [f"venue {n}" for n in range(520)]
+    series = pd.Series((venues * 77)[:39_774], dtype="string")
+    assert _distinct_values(series, "string") == sorted(venues)
+
+
+def test_a_small_value_set_ships_whatever_its_ratio():
+    """Four states over fifty rows is 8%, over `DIMENSION_RATIO` and still obviously a dimension. A
+    ratio says nothing on a frame this small, so a set this small does not have to pass it."""
+    series = pd.Series((["CT", "NY", "NJ", "PA"] * 13)[:50], dtype="string")
+    assert _distinct_values(series, "string") == ["CT", "NJ", "NY", "PA"]
+    assert DIMENSION_RATIO * 50 < 4
+
+
+def test_the_ratio_excludes_a_column_the_ceiling_would_admit():
+    """1000 distinct over 2000 rows is half the frame: well under the ceiling, and not a dimension."""
+    series = pd.Series(list(range(1000)) * 2, dtype="int64")
+    assert len(series) == 2000 and DISTINCT_VALUE_CAP > 1000
+    assert _distinct_values(series, "number") is None
+
+
+def test_the_ceiling_bounds_the_asset_whatever_the_ratio():
+    """A ratio alone would ship 50,000 values off a million-row frame. The ceiling is a ceiling, not
+    a truncation: over it the column offers nothing rather than an arbitrary prefix."""
+    rows = 200_000
+    under = pd.Series((list(range(DISTINCT_VALUE_CAP)) * 100)[:rows], dtype="int64")
+    over = pd.Series((list(range(DISTINCT_VALUE_CAP + 1)) * 100)[:rows], dtype="int64")
     assert len(_distinct_values(under, "number")) == DISTINCT_VALUE_CAP
     assert _distinct_values(over, "number") is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
Closes Stream J. `DISTINCT_VALUE_CAP = 500` was doing three jobs with one number: usefulness, small-frame safety, and asset size. It failed the first two.

**The filed case.** The Grateful Dead archive has 520 distinct venues, so `venue` shipped nothing and `WHERE venue = '` offered no help on `Magoo's Pizza Parlor` — the one column where a visitor most needs it.

**Why raising the count was not an option.** At 1000 it would have admitted `quant`: 1,000 distinct quantities over 10,000 rows, a measure nobody completes. Venue (1.3%) and quant (10%) are separated by their *ratio*, not their count.

| constant | job |
|---|---|
| `DIMENSION_RATIO = 0.05` | is this a dimension worth completing |
| `SMALL_VALUE_SET = 50` | ships regardless — a ratio means nothing on a small frame |
| `DISTINCT_VALUE_CAP = 2000` | asset size only; 5% of a million rows is 50,000 values |

**Verified against `sales.csv`:** the new rule reproduces the old verdict on all nine columns (`quant` at 10% and `date` at 18% still ship nothing) while a venue-shaped column now ships for 6.5 KB of JSON.

`DATASET_SCHEMA`'s `values` description no longer says "within the build's cap", since a threshold restated in prose is a second copy of it (the J5 lesson).

Gate green at 250 tests (was 247). No new `esql.__all__` name, `GRAMMAR` key or slot kind, so no portfolio guard fires — it just needs a rebuild to pick up the venue values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)