### PR TITLE
v1.11.0: publish and enforce operator legality by dtype from one table (G3)

### DIFF
--- a/.claude/status.md
+++ b/.claude/status.md
@@ -153,7 +153,7 @@ expressible in `slot_kinds`/`accepts`**, since that is the channel a host actual
 names, and a `unhandledSlotKinds` check fails its suite when this repo declares a kind it has no case
 for — the reading-side twin of the export-diff guard. Entry values are offered.
 
-- [ ] **G3. `operators` is per clause but legality is also per *dtype*, and that half is unpublished.**
+- [x] **G3. `operators` is per clause but legality is also per *dtype*, and that half is unpublished.**
   Filed from portfolio 2026-07-29, found by testing the engine rather than reading it. The parser
   rejects an ordering comparison on a non-numeric column:
 
@@ -174,6 +174,12 @@ for — the reading-side twin of the export-diff guard. Entry values are offered
   offer illegal operators, or hand-mirror the table above, which is the restatement Stream G exists
   to end. **Portfolio is deliberately not implementing this until it can be read** — the table is
   recorded here as a finding, not as a spec for someone to copy downstream.
+
+  **Shipped in v1.11.0** as `GRAMMAR["operators"]["dtypes"]`, per-operator. See that entry in the
+  settled record. One correction to the table above, found by probing the parser cell by cell rather
+  than trusting the filing: **`date CONTAINS` was accepted**, not rejected, and it worked -- it
+  substring-matched the date's ISO text. That cell is now genuinely rejected, which is the one
+  behavior change in the release.
 
 The front-end currently hand-mirrors rules this engine owns: which slot kinds each clause accepts,
 that `count` is the only aggregate legal on a non-numeric column (mirroring `_parse_aggregate`), that
@@ -282,7 +288,8 @@ H1 shipped; see the settled record. What it leaves open:
 Opened 2026-07-29. Findings from the v1.8.0 work that are **not** about a missing feature: the
 parser accepts a query and answers it wrongly, or refuses one it should take. J4 was the first of
 these and is fixed; these two were turned up alongside it. **Both shipped in v1.9.0**; see that entry
-in the settled record. The stream is closed unless something new lands in it.
+in the settled record. **Reopened 2026-07-29** by K3 below, turned up the same way, by probing the
+parser rather than reading it.
 
 The shape they share with J4 is worth naming, because it is what to look for next: **a rule the
 parser applies by rewriting the query string before it knows the query's structure.** Lowercasing
@@ -336,6 +343,34 @@ patched twice.
 
   **Done in v1.9.0.** Both parameters are required and
   `test_error_type_is_a_required_argument` pins that, so a default cannot come back.
+
+- [ ] **K3. A boolean column compares against a number, because pandas counts bool as numeric.**
+  Found while building G3, by probing every operator against every dtype family. `WHERE credit = 1`
+  parses and **matches the true rows**, `credit = 0` matches the false ones, and `credit = 5` matches
+  nothing:
+
+  ```
+  df.esql.query("SELECT g WHERE flag = 1")       -> the True rows
+  df.esql.query("SELECT g WHERE flag = 5")       -> no rows, no error
+  df.esql.query("SELECT g WHERE flag = 'true'")  -> [WHERE CLAUSE] Invalid value
+  ```
+
+  The asymmetry is what makes it a bug rather than a lenient convenience: the *quoted* boolean is
+  refused while the numeric one is silently accepted, so the two spellings a person is most likely to
+  reach for behave in opposite ways. The cause is `_parse_condition_value`'s coercion chain ending in
+  `is_numeric_dtype(column_dtype)`, which is **True for a bool column**, so a bool falls through to
+  the numeric branch and `1` becomes the value it compares against. `dtype_family` already knows bool
+  is its own family (it checks bool before number, exactly because pandas conflates them), so the fix
+  is to let the coercion dispatch on the family the same way the dtype gate now does.
+
+  **Deliberately not fixed in v1.11.0.** G3 published *operator* legality, and `=` on a boolean column
+  is legal; this is about which *values* that comparison accepts, a second question the same function
+  answers. Folding it in would have put an unrelated behavior change under a release about publishing
+  a table. It is small and self-contained: dispatch the `=`/`!=`/`==` branch on `family` rather than on
+  four dtype predicates, and a bool column then takes only `true`/`false`.
+
+  Worth noting the same chain is why `credit = 5` returns an empty table instead of an error, which is
+  the softer version of the same problem.
 
 ---
 
@@ -800,6 +835,58 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   **Portfolio-side follow-up: rebuild, nothing to change.** No new name in `esql.__all__`, no
   `GRAMMAR` key and no slot kind, so neither guard fires. The visible effect is that a build against
   1.10.0 emits `values` for `venue`, and `WHERE venue = '` starts completing.
+
+## v1.11.0 — operator legality by dtype, published and enforced from one table (2026-07-29)
+
+- [x] **G3.** The second axis of operator legality is now readable: `GRAMMAR["operators"]["dtypes"]`
+  gives, per operator, which of the four dtype families it applies to. Bumped `1.10.0 -> 1.11.0`; the
+  gate is green at **319 tests** (was 250).
+
+  **It is the rule, not a description of it.** `OPERATOR_DTYPES` in `parser/util.py` is a single table
+  that `_parse_condition_value` gates on *before* it coerces anything, and `GRAMMAR` exports verbatim.
+  That is stronger than G1 managed: G1 could only bind its description to behavior with tests, because
+  the parser had no declarative rule to read. Here the export and the enforcement are the same object,
+  so the two cannot drift at all.
+
+  Splitting the gate out made the function say what it means. It answers two questions and used to
+  answer them in one tangle of dtype predicates: *does this operator apply to this kind of column*
+  (about the operator, answerable before the value is read) and *can this value be read as that kind*
+  (about the value). Now the first is a table lookup and the branches below only pick a coercion.
+
+  **The filed table was wrong in one cell, and probing found it.** `date CONTAINS '2020'` was
+  **accepted** and worked, substring-matching the date's ISO rendering, because dates are stored as
+  object dtype and pandas reports object dtype as a *string* dtype -- so the guard meaning "text
+  column" let dates through. Decided to reject it: the behavior was never stated anywhere, publishing
+  it would rest the contract on that loose check, and a range (`date >= '2020-01-01' AND date <=
+  '2020-12-31'`) is the honest spelling. This is the release's one behavior change. The old
+  `is_string_dtype` guard inside the CONTAINS branch is gone, because the gate now answers that
+  question first and a guard that can no longer fire is the K2 mistake again.
+
+  **One vocabulary, in one place.** `dtype_family` is now the only definition of the four families,
+  and `demokit._friendly_type` -- which decides a demo asset's `SchemaColumn.type` -- delegates to it
+  instead of keeping its own copy. That copy was a live hazard, not a tidiness point: a host reads a
+  column's `type` from the asset and looks it up in this table, so if the asset called something a
+  string that the parser treats as a date, every lookup would miss and the host would silently offer
+  nothing. `test_the_families_are_the_vocabulary_a_demo_asset_speaks` binds the two enums together.
+  It also fixed a real disagreement in passing: an all-null object column is a *date* column to the
+  parser, and the old `_friendly_type` called it a string, because it read the first non-null value
+  and there wasn't one.
+
+  **Bound in both directions, and verified to bite.** `tests/parser/test_grammar.py` runs all 32
+  cells (8 operators x 4 families) through the real parser in WHERE, and again in SUCH THAT since the
+  rule belongs to the operator rather than the clause. Tampering confirms each guard fails loudly:
+  claiming date takes CONTAINS fails 1, dropping an operator's rule fails 4, disabling the gate fails
+  23, renaming a family in the asset schema fails 1, and widening `>=` to text fails 2.
+
+  **Turned up and deliberately not fixed: K3**, a boolean column comparing against a number
+  (`WHERE credit = 1` matches the true rows). Filed in Stream K above. That is about which values a
+  legal comparison accepts, not about which comparisons are legal, and it did not belong in a release
+  about publishing the second.
+
+  **Portfolio-side follow-up: one read, no guard fires.** `dtypes` and `dtype_families` are new keys
+  *inside* `GRAMMAR["operators"]`, not new names in `esql.__all__`, and no slot kind changed, so
+  `grammar.json` simply grows two keys. The menu can stop offering `song >` by intersecting the
+  clause's `operators` with `dtypes[op]` for the column's `type`, which it already has from the asset.
 
 ## 3. Engine-side prep for the ESQL demo
 

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -5,7 +5,7 @@ This document contains information about writing ESQL queries. I will be providi
 
 This document is prose. The token sets it describes — the six keywords, the five aggregate functions, the comparison operators, and the semi-join predicate — are defined once in [`src/esql/parser/util.py`](../../src/esql/parser/util.py) as `KEYWORDS`, `AGGREGATE_FUNCTIONS`, `CONDITIONAL_OPERATORS` and `SEMI_JOIN_OPERATOR`, re-exported from `esql`. Read those if you need the authoritative list.
 
-The per-clause rules this document explains in prose are also available machine-readable as `esql.GRAMMAR` (see [`src/esql/grammar.py`](../../src/esql/grammar.py)): which slot kinds each clause accepts, which operators are legal in it, and what it requires. Anything generating a completion menu or a reference table should read that rather than re-deriving it from this page.
+The per-clause rules this document explains in prose are also available machine-readable as `esql.GRAMMAR` (see [`src/esql/grammar.py`](../../src/esql/grammar.py)): which slot kinds each clause accepts, which operators are legal in it, which column types each operator applies to, and what it requires. Anything generating a completion menu or a reference table should read that rather than re-deriving it from this page.
 
 ## Table of Contents
 - [Structure](#structure)
@@ -13,6 +13,7 @@ The per-clause rules this document explains in prose are also available machine-
 - [SELECT](#select)
 - [OVER](#over)
 - [WHERE](#where)
+  - [Which operators apply to which columns](#which-operators-apply-to-which-columns)
   - [CONTAINS](#contains)
   - [HAS](#has)
 - [SUCH THAT](#such-that)
@@ -107,6 +108,22 @@ The WHERE clause determines which rows will be filtered out of the inputted data
 
 WHERE clause conditions can include any column in the inputted datatable followed by a conditional operator (`>`, `<`, `=`, `>=`, `<=`, `!=`, `CONTAINS`) and the value that you want to compare to. The comparison value should be the same datatype as the column you are referencing. 
 
+### Which operators apply to which columns
+
+Not every operator applies to every column. Equality works on all four kinds of column, ordering needs values with an order, and `CONTAINS` needs text:
+
+| column | `=` `!=` | `>` `>=` `<` `<=` | `CONTAINS` |
+|---|---|---|---|
+| number | yes | yes | no |
+| date | yes | yes | no |
+| text | yes | no | yes |
+| boolean | yes | no | no |
+
+An operator used against a column it does not apply to is a parsing error, raised before the value is even read, so `song > 'Dark Star'` is refused rather than answered with an empty table. This is a property of the operator and not of the clause: the same table governs [SUCH THAT](#such-that). [HAVING](#having) has no place in it, because it compares aggregates and every aggregate is numeric.
+
+A tool that offers completions should read this from `esql.GRAMMAR["operators"]["dtypes"]` rather than copying the table, since the parser enforces the same structure the export is built from.
+
+
 Conditions can be combined with `AND` and `OR`. The `NOT` operator can also be used for negation. 
 
 Conditions can handle `()` for order of operations, and they interpret `==` as `=`. A boolean column (like `credit` in the `sales` table) can also be a stand alone condition since it will implictly convert to a boolean.
@@ -126,7 +143,7 @@ Below is an example of a valid WHERE clause:
 Three rules apply to it and not to the other operators:
 
 - **It is case insensitive.** `'err'`, `'ERR'` and `'Err'` all match `Cherry`. This is the same behavior as SQL's `LIKE '%err%'`.
-- **Both sides must be text.** The column has to be a text column and the value has to be quoted. `quant CONTAINS '5'` is a parsing error, not a match against the digits of a number.
+- **Both sides must be text.** The column has to be a text column and the value has to be quoted. `quant CONTAINS '5'` is a parsing error, not a match against the digits of a number, and a date column is not text either: `date CONTAINS '2020'` is refused rather than matched against how the date is written. Use a range for that (`date >= '2020-01-01' AND date <= '2020-12-31'`).
 - **It is not available in HAVING**, which compares aggregates, and every aggregate is numeric.
 
 It works in [SUCH THAT](#such-that) exactly as it does here, prepended by a group name:
@@ -160,7 +177,7 @@ Four rules to know:
 ## SUCH THAT
 The SUCH THAT clause determines which of the remaining rows will be used to compute aggregates within a group. The SUCH THAT clause should contain a section for each defined group in the [OVER](#over) clause. These sections must be divided by commas, must contain only one group, and must not contain a group that is already defined in another section of the SUCH THAT clause.
 
-SUCH THAT clause conditions can include any column in the inputted datatable but every column name must start with the group name of the section combined using dot notation (e.g. `group1.month`). The group and column is followed by a conditional operator (`>`, `<`, `=`, `>=`, `<=`, `!=`, `CONTAINS`) and the value that you want to compare to. The comparison value should be the same datatype as the column you are referencing.
+SUCH THAT clause conditions can include any column in the inputted datatable but every column name must start with the group name of the section combined using dot notation (e.g. `group1.month`). The group and column is followed by a conditional operator (`>`, `<`, `=`, `>=`, `<=`, `!=`, `CONTAINS`) and the value that you want to compare to. The comparison value should be the same datatype as the column you are referencing. [Which operators apply to which columns](#which-operators-apply-to-which-columns) governs here exactly as it does in WHERE.
 
 Conditions can be combined with `AND` and `OR`. The `NOT` operator can also be used for negation. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.10.0"
+version = "1.11.0"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/esql/demokit.py
+++ b/src/esql/demokit.py
@@ -29,6 +29,7 @@ from pandas.api import types as pdt
 import esql.accessor  # noqa: F401  (registers the .esql accessor)
 from esql.accessor import _enforce_allowed_dtypes
 from esql.dataset_schema import DATASET_SCHEMA, DatasetSchemaError, validate_dataset
+from esql.parser.util import dtype_family
 
 # Whether a column ships its distinct values, for a host to offer as completions ("WHERE song = '"
 # should suggest real song names). The question is "does completing this column help?", and the
@@ -52,15 +53,14 @@ DISTINCT_VALUE_CAP = 2000
 
 
 def _friendly_type(series: pd.Series) -> str:
-    dt = series.dtype
-    if pdt.is_bool_dtype(dt):
-        return "boolean"
-    if pdt.is_numeric_dtype(dt):
-        return "number"
-    non_null = series.dropna()
-    if len(non_null) and hasattr(non_null.iloc[0], "isoformat"):
-        return "date"
-    return "string"
+    """The asset's `SchemaColumn.type` for a column of the enforced frame.
+
+    Delegates to the parser's `dtype_family`, because the asset and the parser have to agree on what
+    a column is: the asset tells a host `venue` is a string, and the host asks `GRAMMAR` which
+    operators apply to a string. Two copies of this mapping is two chances for the answer a host is
+    given to differ from the one the engine enforces.
+    """
+    return dtype_family(series.dtype)
 
 
 def _value_text(value) -> str:

--- a/src/esql/grammar.py
+++ b/src/esql/grammar.py
@@ -18,9 +18,11 @@ from esql.parser.util import (
     AGGREGATE_FUNCTIONS,
     CONDITIONAL_OPERATORS,
     DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS,
+    DTYPE_FAMILIES,
     HAVING_OPERATORS,
     KEYWORDS,
     NUMERIC_AGGREGATE_FUNCTIONS,
+    OPERATOR_DTYPES,
     QUOTE_CHARACTERS,
     QUOTE_ESCAPE,
     SEMI_JOIN_OPERATOR,
@@ -140,5 +142,13 @@ GRAMMAR = {
         "text": list(TEXT_OPERATORS),
         "semi_join": SEMI_JOIN_OPERATOR,
         "logical": [op.value.upper() for op in LogicalOperator],
+        # The second axis of operator legality, per G3. `clauses[c]["operators"]` says which
+        # operators a clause takes; this says which column dtypes each operator applies to, and a
+        # condition needs both. The keys of `dtypes` are the four families in `dtype_families`,
+        # which are the same values a demo asset's `SchemaColumn.type` carries, so a host holding a
+        # column's type can look up what may follow it. `_parse_condition_value` gates on this same
+        # table, so it is the rule and not a description of one.
+        "dtype_families": list(DTYPE_FAMILIES),
+        "dtypes": {op: list(families) for op, families in OPERATOR_DTYPES.items()},
     },
 }

--- a/src/esql/parser/util.py
+++ b/src/esql/parser/util.py
@@ -56,6 +56,27 @@ CONDITIONAL_OPERATORS = ("CONTAINS", ">=", "<=", "!=", "==", ">", "<", "=")
 # word boundaries.
 TEXT_OPERATORS = ("CONTAINS",)
 
+# The four value families every column is coerced into (`accessor._enforce_allowed_dtypes`), and the
+# vocabulary the dtype rules below are written in. Also what a demo asset's `SchemaColumn.type`
+# carries, so a host reading `OPERATOR_DTYPES` is already holding the key to look up with.
+DTYPE_FAMILIES = ("number", "date", "string", "boolean")
+
+# Which families each comparison operator accepts. Legality has two axes: the clause (below) and the
+# column's dtype, and this is the second. `_parse_condition_value` gates on this table before it
+# coerces anything, so it is the rule rather than a description of it -- which is what lets `GRAMMAR`
+# publish it. Ordering a text or boolean column is meaningless, and CONTAINS is a substring test, so
+# it needs text.
+OPERATOR_DTYPES = {
+    "=": DTYPE_FAMILIES,
+    "==": DTYPE_FAMILIES,
+    "!=": DTYPE_FAMILIES,
+    ">": ("number", "date"),
+    ">=": ("number", "date"),
+    "<": ("number", "date"),
+    "<=": ("number", "date"),
+    "CONTAINS": ("string",),
+}
+
 # The semi-join predicate. `<key> HAS <condition>` keeps rows whose `<key>` value belongs to some
 # row satisfying `<condition>`, which is how a query reaches across grains without a join. It is
 # not a comparison and so is not one of CONDITIONAL_OPERATORS: what follows it is a whole
@@ -97,6 +118,26 @@ DATE_PATTERN = re.compile(r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}$")
 # parser knew which words were identifiers, and resolution was a plain `in column_dtypes` against
 # the frame's real keys, so a frame with a `Cust` column could not be queried in any spelling and
 # the error blamed `'cust'`, a word the query never contained. See `.claude/status.md`, K1.
+
+
+def dtype_family(dtype: np.dtype) -> str:
+    """Which of `DTYPE_FAMILIES` a column's dtype belongs to.
+
+    Reads an **enforced** dtype, which is the only kind the parser ever sees: the accessor coerces
+    every column into one of four families before parsing (`accessor._enforce_allowed_dtypes`), and
+    dates land as `datetime.date` objects, so object dtype means date. Bool is checked before number
+    because pandas counts it as numeric and here it is its own family.
+
+    Public because `demokit` needs the same answer for a demo asset's `SchemaColumn.type`, and two
+    copies of this mapping would let the asset disagree with the parser about what a column is.
+    """
+    if pd.api.types.is_bool_dtype(dtype):
+        return "boolean"
+    if pd.api.types.is_numeric_dtype(dtype):
+        return "number"
+    if pd.api.types.is_object_dtype(dtype):
+        return "date"
+    return "string"
 
 
 def _resolve_column(name: str, column_dtypes: dict[str, np.dtype], error_type: ParsingErrorType) -> str | None:
@@ -717,7 +758,27 @@ def _parse_condition_value(
     condition: str,
     error_type: ParsingErrorType,
 ) -> float | bool | str | date:
+    """Read the right side of a comparison as the typed value its column holds.
+
+    Two gates, in this order. First the **dtype** gate, `OPERATOR_DTYPES`: whether this operator
+    means anything against this family of column at all, which is a question about the operator and
+    answerable before the value is looked at. Then the coercion below, which is whether *this* value
+    can be read as that family. Splitting them is what lets `GRAMMAR` publish the first as a table
+    (G3) instead of a host inferring it from which conditions happen to be refused.
+    """
     value = value.strip()
+
+    allowed_families = OPERATOR_DTYPES.get(operator)
+    if allowed_families is None:
+        raise ParsingError(error_type, f"Invalid operator in condition: '{condition}'", token=condition)
+
+    family = dtype_family(column_dtype)
+    if family not in allowed_families:
+        raise ParsingError(
+            error_type,
+            f"'{operator}' does not apply to a {family} column in condition: '{condition}'",
+            token=condition,
+        )
 
     if operator in [">=", "<=", ">", "<"]:
         if _is_quoted_date(value) and pd.api.types.is_object_dtype(column_dtype):
@@ -737,17 +798,16 @@ def _parse_condition_value(
         )
 
     elif operator == "CONTAINS":
-        if not pd.api.types.is_string_dtype(column_dtype):
-            raise ParsingError(
-                error_type, f"CONTAINS needs a text column in condition: '{condition}'", token=condition
-            )
         if not _is_quoted(value):
             raise ParsingError(
                 error_type, f"CONTAINS needs a quoted text value in condition: '{condition}'", token=condition
             )
         return _unquote(value)
 
-    elif operator in ["=", "==", "!="]:
+    # Every operator the dtype gate let through is one of the eight, so this is `=`, `==` or `!=`.
+    # The dtype checks in these branches pick which family's *coercion* to apply, not whether the
+    # comparison is legal -- that question was already answered above.
+    else:
         if value.lower() in ["true", "false"] and pd.api.types.is_bool_dtype(column_dtype):
             return value.lower() == "true"
         elif _is_quoted_date(value) and pd.api.types.is_object_dtype(column_dtype):
@@ -767,8 +827,6 @@ def _parse_condition_value(
         raise ParsingError(
             error_type, f"Invalid column reference or value in condition: '{condition}'", token=condition
         )
-
-    raise ParsingError(error_type, f"Invalid operator in condition: '{condition}'", token=condition)
 
 
 ###########################################################################

--- a/tests/execution/test_contains.py
+++ b/tests/execution/test_contains.py
@@ -73,7 +73,7 @@ def test_contains_does_not_split_a_column_name_that_starts_with_it():
 
 
 def test_contains_on_a_numeric_column_is_a_parsing_error(song_data: pd.DataFrame):
-    with pytest.raises(ParsingError, match="CONTAINS needs a text column"):
+    with pytest.raises(ParsingError, match="'CONTAINS' does not apply to a number column"):
         song_data.esql.query("SELECT song, seconds.sum WHERE seconds CONTAINS '12'")
 
 

--- a/tests/parser/test_grammar.py
+++ b/tests/parser/test_grammar.py
@@ -15,13 +15,17 @@ import json
 import pandas as pd
 import pytest
 
+from esql.dataset_schema import DATASET_SCHEMA
 from esql.grammar import GRAMMAR
 from esql.parser.error import ParsingError
 from esql.parser.util import (
     AGGREGATE_FUNCTIONS,
     CONDITIONAL_OPERATORS,
+    DTYPE_FAMILIES,
     KEYWORDS,
+    OPERATOR_DTYPES,
     SEMI_JOIN_OPERATOR,
+    dtype_family,
 )
 
 ALL_OPERATORS = (*CONDITIONAL_OPERATORS, SEMI_JOIN_OPERATOR)
@@ -222,3 +226,90 @@ def test_only_the_delimiter_in_use_is_doubled_as_described():
 
     summary = GRAMMAR["literals"]["text"]["summary"]
     assert "Only the delimiter in use is doubled" in summary
+
+
+###############################################################################
+# Operator legality by dtype (G3)
+###############################################################################
+# The second axis. `clauses[c]["operators"]` is the first, and a host reading only that offers
+# `song >` on a text column and watches the engine refuse it. Every cell of the table is bound below,
+# in both directions, so a rule the parser applies cannot go unpublished and a published rule cannot
+# be wrong.
+COLUMN_OF_FAMILY = {"number": "num", "date": "dt", "string": "txt", "boolean": "flag"}
+VALUE_OF_FAMILY = {"number": "1", "date": "'2020-01-01'", "string": "'a'", "boolean": "true"}
+CELLS = [(op, family) for op in OPERATOR_DTYPES for family in DTYPE_FAMILIES]
+
+
+@pytest.fixture
+def typed() -> pd.DataFrame:
+    """One column per dtype family, plus a text column to group by."""
+    return pd.DataFrame(
+        {
+            "num": [1, 2],
+            "dt": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+            "txt": ["a", "b"],
+            "flag": [True, False],
+            "g": ["x", "y"],
+        }
+    )
+
+
+def test_the_published_families_are_the_ones_the_parser_sorts_columns_into(typed: pd.DataFrame):
+    enforced = typed.esql.data
+    assert GRAMMAR["operators"]["dtype_families"] == list(DTYPE_FAMILIES)
+    for family, column in COLUMN_OF_FAMILY.items():
+        assert dtype_family(enforced[column].dtype) == family
+
+
+def test_the_families_are_the_vocabulary_a_demo_asset_speaks():
+    """A host looks a column's `type` up in this table, so the two published artifacts have to use
+    one set of names. If they diverge, every lookup misses and the host silently offers nothing."""
+    assert sorted(DATASET_SCHEMA["$defs"]["ColumnType"]["enum"]) == sorted(DTYPE_FAMILIES)
+
+
+def test_every_comparison_operator_has_a_dtype_rule():
+    """A new operator cannot reach a host undeclared: `_parse_condition_value` reads this table, so
+    an operator missing from it is rejected outright rather than defaulting to legal."""
+    assert set(GRAMMAR["operators"]["dtypes"]) == set(CONDITIONAL_OPERATORS)
+
+
+def test_every_rule_names_only_real_families():
+    for operator, families in GRAMMAR["operators"]["dtypes"].items():
+        assert families, f"{operator} applies to nothing"
+        for family in families:
+            assert family in DTYPE_FAMILIES, f"{operator} lists unknown dtype family {family!r}"
+
+
+@pytest.mark.parametrize(("operator", "family"), CELLS)
+def test_a_listed_dtype_parses_and_an_unlisted_one_raises(operator: str, family: str, typed: pd.DataFrame):
+    column, value = COLUMN_OF_FAMILY[family], VALUE_OF_FAMILY[family]
+    query = f"SELECT g WHERE {column} {operator} {value}"
+    if family in GRAMMAR["operators"]["dtypes"][operator]:
+        typed.esql.validate(query)  # must not raise
+    else:
+        with pytest.raises(ParsingError, match="does not apply to"):
+            typed.esql.validate(query)
+
+
+@pytest.mark.parametrize(("operator", "family"), CELLS)
+def test_the_dtype_rule_is_the_same_in_such_that(operator: str, family: str, typed: pd.DataFrame):
+    """The table is a property of the operator, not of the clause, and SUCH THAT compares raw column
+    values exactly as WHERE does. HAVING has no cell in it: it compares aggregates, which are always
+    numeric."""
+    column, value = COLUMN_OF_FAMILY[family], VALUE_OF_FAMILY[family]
+    query = f"SELECT g, g1.num.sum OVER g1 SUCH THAT g1.{column} {operator} {value}"
+    if family in GRAMMAR["operators"]["dtypes"][operator]:
+        typed.esql.validate(query)  # must not raise
+    else:
+        with pytest.raises(ParsingError, match="does not apply to"):
+            typed.esql.validate(query)
+
+
+def test_contains_no_longer_reaches_a_date_column(typed: pd.DataFrame):
+    """The one cell this changed. `dt CONTAINS '2020'` used to parse and substring-match the date's
+    ISO text, because pandas reports the object dtype dates are stored as as a string dtype -- so the
+    guard meaning "text column" let dates through. It was never a stated behavior, and publishing it
+    would have rested the contract on that loose check."""
+    assert "date" not in GRAMMAR["operators"]["dtypes"]["CONTAINS"]
+    with pytest.raises(ParsingError, match="'CONTAINS' does not apply to a date column"):
+        typed.esql.validate("SELECT g WHERE dt CONTAINS '2020'")

--- a/tests/parser/test_util.py
+++ b/tests/parser/test_util.py
@@ -373,6 +373,10 @@ def test_parse_where_clause_raises_error_for_missing_conditional_operators(colum
 
 
 def test_parse_where_clause_raises_error_for_invalid_values(column_dtypes: dict[str, np.dtype]):
+    """Two refusals live here, and they are answered at different points. `cust > 'Dan'` and
+    `credit > true` are refused for the *operator*, before the value is read at all, because ordering
+    a text or boolean column means nothing (`OPERATOR_DTYPES`). The rest are refused for the
+    *value*: the operator applies, and `123` is not something a text column holds."""
     invalid_values = [
         "cust = 123",
         "cust = 12.3",
@@ -387,7 +391,8 @@ def test_parse_where_clause_raises_error_for_invalid_values(column_dtypes: dict[
         with pytest.raises(ParsingError) as parsingError:
             parse_where_clause(where_clause=invalid_value, column_dtypes=column_dtypes)
         assert parsingError.value.error_type == ParsingErrorType.WHERE_CLAUSE and any(
-            error in parsingError.value.message for error in ["Invalid value", "Invalid column reference"]
+            error in parsingError.value.message
+            for error in ["Invalid value", "Invalid column reference", "does not apply to"]
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
`GRAMMAR["clauses"][c]["operators"]` carried only the per-clause axis, so a host reading it offers `song >` on a text column and the engine refuses. Portfolio hit this and deliberately waited rather than hand-mirroring the table.

## What ships

`GRAMMAR["operators"]["dtypes"]` — per operator, which of the four dtype families it applies to:

```json
{"=": ["number","date","string","boolean"], ">": ["number","date"], "CONTAINS": ["string"], ...}
```

**It is the rule, not a description of one.** `OPERATOR_DTYPES` is a single table in `parser/util.py`; `_parse_condition_value` gates on it before coercing anything, and the export is that table verbatim. G1 could only bind its description to behavior with tests, because the parser had no declarative rule to read — here the export and the enforcement are the same object, so they cannot drift.

Splitting the gate out also made the function say what it means. It answers two questions and used to answer them in one tangle of dtype predicates: does this operator apply to this kind of column (about the operator, answerable before the value is read), and can this value be read as that kind (about the value). The first is now a lookup; the branches below only pick a coercion.

## One behavior change

The filed table said `date CONTAINS` was rejected. Probing every cell showed it was **accepted, and worked** — it substring-matched the date's ISO text, because dates are stored as object dtype and pandas reports object dtype as a string dtype, so the guard meaning "text column" let dates through. Now rejected: it was never a stated behavior, publishing it would rest the contract on that loose check, and `date >= '2020-01-01' AND date <= '2020-12-31'` is the honest spelling.

## One vocabulary

`dtype_family` is now the only definition of the four families, and `demokit._friendly_type` delegates to it. Not tidiness: a host reads a column's `type` from the demo asset and looks it up in this table, so an asset calling something a string that the parser treats as a date would make every lookup miss silently. A test binds the two enums together. It also fixed a real disagreement — an all-null object column is a date column to the parser, and the old `_friendly_type` called it a string.

## Verification

319 tests (was 250). All 32 cells (8 operators × 4 families) run through the real parser in WHERE, and again in SUCH THAT since the rule belongs to the operator not the clause. Tamper-checked that each guard bites: claiming date takes CONTAINS fails 1, dropping an operator's rule fails 4, disabling the gate fails 23, renaming a family in the asset schema fails 1, widening `>=` to text fails 2.

Also filed, deliberately unfixed here: **K3**, a boolean column comparing against a number (`WHERE credit = 1` matches the true rows, `credit = 'true'` is refused). That is about which values a legal comparison accepts, not which comparisons are legal.

Portfolio-side: two new keys inside `GRAMMAR["operators"]`, no new `esql.__all__` name and no slot-kind change, so no guard fires. The menu stops offering `song >` by intersecting the clause's `operators` with `dtypes[op]` for the column's type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)