### PR TITLE
v1.12.0: read a comparison value as its column's own kind (K3)

### DIFF
--- a/.claude/status.md
+++ b/.claude/status.md
@@ -289,7 +289,7 @@ Opened 2026-07-29. Findings from the v1.8.0 work that are **not** about a missin
 parser accepts a query and answers it wrongly, or refuses one it should take. J4 was the first of
 these and is fixed; these two were turned up alongside it. **Both shipped in v1.9.0**; see that entry
 in the settled record. **Reopened 2026-07-29** by K3 below, turned up the same way, by probing the
-parser rather than reading it.
+parser rather than reading it, and closed again by v1.12.0.
 
 The shape they share with J4 is worth naming, because it is what to look for next: **a rule the
 parser applies by rewriting the query string before it knows the query's structure.** Lowercasing
@@ -344,7 +344,7 @@ patched twice.
   **Done in v1.9.0.** Both parameters are required and
   `test_error_type_is_a_required_argument` pins that, so a default cannot come back.
 
-- [ ] **K3. A boolean column compares against a number, because pandas counts bool as numeric.**
+- [x] **K3. A boolean column compares against a number, because pandas counts bool as numeric.**
   Found while building G3, by probing every operator against every dtype family. `WHERE credit = 1`
   parses and **matches the true rows**, `credit = 0` matches the false ones, and `credit = 5` matches
   nothing:
@@ -371,6 +371,11 @@ patched twice.
 
   Worth noting the same chain is why `credit = 5` returns an empty table instead of an error, which is
   the softer version of the same problem.
+
+  **Shipped in v1.12.0.** The fix found a second instance of the same root cause on the way in: a date
+  column accepted *any* quoted text, so `date = 'hello'` matched nothing and `date != 'hello'` matched
+  everything. Same chain, same shape, both closed by one dispatch. See that entry in the settled
+  record.
 
 ---
 
@@ -887,6 +892,58 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   *inside* `GRAMMAR["operators"]`, not new names in `esql.__all__`, and no slot kind changed, so
   `grammar.json` simply grows two keys. The menu can stop offering `song >` by intersecting the
   clause's `operators` with `dtypes[op]` for the column's `type`, which it already has from the asset.
+
+## v1.12.0 — a comparison value is read as its column's own kind (2026-07-30)
+
+- [x] **K3, and a second instance of it found on the way in.** Bumped `1.11.0 -> 1.12.0`; the gate is
+  green at **348 tests** (was 319).
+
+  **What was wrong.** `_parse_condition_value` chose its coercion with a chain of pandas dtype
+  predicates, one chain for ordering and a near-identical one for equality, and both ended by asking
+  whether the column was numeric. Two families answer that question wrongly:
+
+  | written | did | does |
+  |---|---|---|
+  | `credit = 1` | matched the true rows | refused |
+  | `credit = 0` | matched the false rows | refused |
+  | `credit = 5` | matched nothing, no error | refused |
+  | `credit = 'true'` | refused | refused |
+  | `date = 'hello'` | matched nothing, no error | refused |
+  | `date != 'hello'` | matched **everything**, no error | refused |
+
+  A bool column is numeric to pandas, so a boolean fell into the numeric branch and `1` became the
+  value. Object dtype is a *string* dtype to pandas, so any quoted text fell into the text branch and
+  reached a date column as a string, comparing unequal to every date.
+
+  **Both are the same failure mode, and it is the one worth naming: an answer instead of an error.**
+  Nothing raised. `credit = 1` looks like it worked and did something defensible; `date != 'hello'`
+  returned the whole table. A person reading either result has no way to know the query was refused
+  on its merits or answered on a misreading. That is why this was worth a release rather than a
+  footnote, and it is the same reason J4 was.
+
+  **The fix is one dispatch on `dtype_family`,** which G3 had already established as the one place
+  the four families are defined. Ordering and equality no longer have a chain each: the value is read
+  as the column's family, and the operator only decides whether ordering is allowed at all (which the
+  `OPERATOR_DTYPES` gate answered before this point). `CONTAINS` stays the single exception, because
+  its value is a substring rather than a value of the column's kind. Two small helpers, `_numeric_value`
+  and `_date_value`, replace what the two chains each spelled out inline.
+
+  So the released shape is: **`OPERATOR_DTYPES` says whether the operator applies, `dtype_family` says
+  how to read the value.** Neither question is answered by asking pandas about a dtype in the middle of
+  the other one, which is what let a bool and a date slip through.
+
+  **The error messages now name which question refused the query,** because the two call for different
+  fixes: `'>' does not apply to a string column` means change the operator, `A text value must be
+  quoted` means write the value differently. `test_parse_where_clause_raises_error_for_invalid_values`
+  went from asserting that *some* error was raised to asserting *which*, over all ten cases.
+
+  Covered by `tests/parser/test_condition_values.py` (29 tests) over all four families in WHERE and
+  SUCH THAT. Verified the guards bite: restoring the numeric fallback for bools fails 7, letting a date
+  take any quoted text fails 8, and letting a text column take an unquoted word fails 4.
+
+  **Portfolio-side follow-up: none, but worth a look at the curated examples.** No export changed.
+  Any query spelling a boolean as `= 1` or comparing a date against non-date text would now be a
+  parsing error rather than a quiet result, and `esql-smoke` catches it if one exists.
 
 ## 3. Engine-side prep for the ESQL demo
 

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -121,6 +121,17 @@ Not every operator applies to every column. Equality works on all four kinds of 
 
 An operator used against a column it does not apply to is a parsing error, raised before the value is even read, so `song > 'Dark Star'` is refused rather than answered with an empty table. This is a property of the operator and not of the clause: the same table governs [SUCH THAT](#such-that). [HAVING](#having) has no place in it, because it compares aggregates and every aggregate is numeric.
 
+The value is then read as the column's own kind, and only that kind:
+
+| column | value is written as | examples |
+|---|---|---|
+| number | a bare number | `quant > 500`, `quant = 12.5` |
+| date | a quoted `YYYY-MM-DD` or `YYYY/MM/DD` | `date >= '2020-01-01'` |
+| text | a quoted value (see [Text values](#text-values)) | `prod = 'Ham'` |
+| boolean | `true` or `false`, unquoted, any case | `credit = true` |
+
+A value written as some other kind is a parsing error, not a comparison that quietly matches nothing: `credit = 1` and `date = 'hello'` are both refused.
+
 A tool that offers completions should read this from `esql.GRAMMAR["operators"]["dtypes"]` rather than copying the table, since the parser enforces the same structure the export is built from.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.11.0"
+version = "1.12.0"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/esql/parser/util.py
+++ b/src/esql/parser/util.py
@@ -780,53 +780,58 @@ def _parse_condition_value(
             token=condition,
         )
 
-    if operator in [">=", "<=", ">", "<"]:
-        if _is_quoted_date(value) and pd.api.types.is_object_dtype(column_dtype):
-            try:
-                date_str = _unquote(value).replace("/", "-")
-                return datetime.strptime(date_str, "%Y-%m-%d").date()
-            except ValueError:
-                raise ParsingError(error_type, f"Invalid date in condition: '{condition}'", token=condition) from None
-        elif pd.api.types.is_numeric_dtype(column_dtype):
-            try:
-                value = float(value)
-                return int(value) if value.is_integer() else value
-            except Exception:
-                raise ParsingError(error_type, f"Invalid value in condition: '{condition}'", token=condition) from None
-        raise ParsingError(
-            error_type, f"Invalid column reference or value in condition: '{condition}'", token=condition
-        )
-
-    elif operator == "CONTAINS":
+    # CONTAINS is the one operator whose value is not read as the column's own family: it is a
+    # substring of the text, so any quoted text will do.
+    if operator == "CONTAINS":
         if not _is_quoted(value):
             raise ParsingError(
                 error_type, f"CONTAINS needs a quoted text value in condition: '{condition}'", token=condition
             )
         return _unquote(value)
 
-    # Every operator the dtype gate let through is one of the eight, so this is `=`, `==` or `!=`.
-    # The dtype checks in these branches pick which family's *coercion* to apply, not whether the
-    # comparison is legal -- that question was already answered above.
-    else:
-        if value.lower() in ["true", "false"] and pd.api.types.is_bool_dtype(column_dtype):
-            return value.lower() == "true"
-        elif _is_quoted_date(value) and pd.api.types.is_object_dtype(column_dtype):
-            try:
-                date_str = _unquote(value).replace("/", "-")
-                return datetime.strptime(date_str, "%Y-%m-%d").date()
-            except ValueError:
-                raise ParsingError(error_type, f"Invalid date in condition: '{condition}'", token=condition) from None
-        elif _is_quoted(value) and pd.api.types.is_string_dtype(column_dtype):
-            return _unquote(value)
-        elif pd.api.types.is_numeric_dtype(column_dtype):
-            try:
-                value = float(value)
-                return int(value) if value.is_integer() else value
-            except Exception:
-                raise ParsingError(error_type, f"Invalid value in condition: '{condition}'", token=condition) from None
-        raise ParsingError(
-            error_type, f"Invalid column reference or value in condition: '{condition}'", token=condition
-        )
+    # Everything else compares against a value of the column's own family, so the coercion is chosen
+    # by the family and not by the operator. Ordering and equality used to have a chain each, and
+    # both chains ended by asking pandas whether the dtype was numeric -- which is True for a bool
+    # column, so `credit = 1` read 1 as the value and matched the true rows (K3).
+    if family == "number":
+        return _numeric_value(value, condition, error_type)
+    if family == "date":
+        return _date_value(value, condition, error_type)
+    if family == "boolean":
+        if value.lower() not in ["true", "false"]:
+            raise ParsingError(
+                error_type,
+                f"A boolean column compares against true or false in condition: '{condition}'",
+                token=condition,
+            )
+        return value.lower() == "true"
+    if not _is_quoted(value):
+        raise ParsingError(error_type, f"A text value must be quoted in condition: '{condition}'", token=condition)
+    return _unquote(value)
+
+
+def _numeric_value(value: str, condition: str, error_type: ParsingErrorType) -> float | int:
+    try:
+        number = float(value)
+    except ValueError:
+        raise ParsingError(error_type, f"Invalid value in condition: '{condition}'", token=condition) from None
+    return int(number) if number.is_integer() else number
+
+
+def _date_value(value: str, condition: str, error_type: ParsingErrorType) -> date:
+    """A date value is a quoted `YYYY-MM-DD` (or `YYYY/MM/DD`), and nothing else is guessed at.
+
+    Anything quoted used to reach a date column as *text*, because pandas reports the object dtype
+    dates are stored as as a string dtype: `date = 'hello'` compared a string against date objects
+    and returned nothing, while `date != 'hello'` returned everything. Both were answers to a
+    question nobody asked (K3).
+    """
+    if not _is_quoted_date(value):
+        raise ParsingError(error_type, f"Invalid date in condition: '{condition}'", token=condition)
+    try:
+        return datetime.strptime(_unquote(value).replace("/", "-"), "%Y-%m-%d").date()
+    except ValueError:
+        raise ParsingError(error_type, f"Invalid date in condition: '{condition}'", token=condition) from None
 
 
 ###########################################################################

--- a/tests/execution/test_entry_values.py
+++ b/tests/execution/test_entry_values.py
@@ -185,8 +185,9 @@ def test_offsetting_a_non_numeric_attribute_is_a_parsing_error(monthly_data: pd.
 
 
 def test_an_unknown_word_is_read_as_a_literal_not_a_reference(monthly_data: pd.DataFrame):
-    # `nope` is no column, so this never becomes an entry value and fails as a bad value instead.
-    with pytest.raises(ParsingError, match="Invalid column reference or value"):
+    # `nope` is no column, so this never becomes an entry value and fails as a bad value instead:
+    # against a text column, an unquoted word is a literal that forgot its quotes.
+    with pytest.raises(ParsingError, match="A text value must be quoted"):
         monthly_data.esql.query("SELECT cust, g1.quant.sum OVER g1 SUCH THAT g1.cust = nope")
 
 

--- a/tests/parser/test_condition_values.py
+++ b/tests/parser/test_condition_values.py
@@ -1,0 +1,125 @@
+"""How the right side of a comparison is read, per dtype family (K3).
+
+`OPERATOR_DTYPES` answers whether an operator applies to a column at all; these cover the question
+after it, which value that comparison accepts. Both used to be answered by one chain of pandas dtype
+predicates, and it ended by asking whether the dtype was numeric -- True for a bool column, so a
+boolean compared against a number, and anything quoted reached a date column as text because pandas
+reports the object dtype dates are stored as as a string dtype.
+
+The failures those produced were the dangerous kind: no error, and an answer to a question nobody
+asked. `credit = 1` matched the true rows, `date = 'hello'` matched nothing, and `date != 'hello'`
+matched everything.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from esql.parser.error import ParsingError
+
+
+@pytest.fixture
+def data() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "n": [1, 2, 3],
+            "dt": pd.to_datetime(["2020-01-01", "2020-06-15", "2021-03-02"]),
+            "txt": ["a", "b", "c"],
+            "flag": [True, False, True],
+            "g": ["x", "y", "z"],
+        }
+    )
+
+
+###############################################################################
+# Boolean columns take booleans, and nothing else
+###############################################################################
+@pytest.mark.parametrize("written", ["true", "TRUE", "True"])
+def test_a_boolean_column_takes_a_boolean_literal_in_any_case(written: str, data: pd.DataFrame):
+    assert list(data.esql.query(f"SELECT g WHERE flag = {written}")["g"]) == ["x", "z"]
+
+
+def test_a_boolean_column_takes_false_as_well(data: pd.DataFrame):
+    assert list(data.esql.query("SELECT g WHERE flag = false")["g"]) == ["y"]
+
+
+@pytest.mark.parametrize("value", ["1", "0", "5", "'true'", "yes"])
+def test_a_boolean_column_refuses_anything_that_is_not_a_boolean(value: str, data: pd.DataFrame):
+    """`1` is the one that mattered: it used to parse, because pandas counts a bool column as
+    numeric, and `flag = 1` then matched the true rows. `'true'` was already refused, which is what
+    made the pair incoherent -- the quoted spelling raised while the numeric one answered."""
+    with pytest.raises(ParsingError, match="compares against true or false"):
+        data.esql.query(f"SELECT g WHERE flag = {value}")
+
+
+def test_negating_a_boolean_comparison_is_still_a_boolean_comparison(data: pd.DataFrame):
+    assert list(data.esql.query("SELECT g WHERE flag != true")["g"]) == ["y"]
+
+
+###############################################################################
+# Date columns take a quoted date, and nothing else
+###############################################################################
+@pytest.mark.parametrize("written", ["'2020-06-15'", "'2020/06/15'"])
+def test_a_date_column_takes_a_quoted_date_in_either_separator(written: str, data: pd.DataFrame):
+    assert list(data.esql.query(f"SELECT g WHERE dt = {written}")["g"]) == ["y"]
+
+
+def test_a_date_column_orders_by_a_quoted_date(data: pd.DataFrame):
+    assert list(data.esql.query("SELECT g WHERE dt >= '2020-06-15'")["g"]) == ["y", "z"]
+
+
+@pytest.mark.parametrize("operator", ["=", "!=", ">", "<="])
+def test_a_date_column_refuses_text_that_is_not_a_date(operator: str, data: pd.DataFrame):
+    """This is the silent half of K3. Under `=` the text was compared against date objects and
+    matched nothing; under `!=` it matched everything. Neither raised."""
+    with pytest.raises(ParsingError, match="Invalid date"):
+        data.esql.query(f"SELECT g WHERE dt {operator} 'hello'")
+
+
+def test_a_date_column_refuses_an_unquoted_date(data: pd.DataFrame):
+    with pytest.raises(ParsingError, match="Invalid date"):
+        data.esql.query("SELECT g WHERE dt = 2020-06-15")
+
+
+def test_a_date_column_refuses_a_quoted_impossible_date(data: pd.DataFrame):
+    """Right shape, no such day. `_is_quoted_date` matches the pattern; strptime is what knows
+    February has 28 days."""
+    with pytest.raises(ParsingError, match="Invalid date"):
+        data.esql.query("SELECT g WHERE dt = '2020-02-30'")
+
+
+###############################################################################
+# Text and number columns
+###############################################################################
+def test_a_text_column_takes_a_quoted_value(data: pd.DataFrame):
+    assert list(data.esql.query("SELECT g WHERE txt = 'b'")["g"]) == ["y"]
+
+
+@pytest.mark.parametrize("value", ["b", "5", "true"])
+def test_a_text_column_refuses_an_unquoted_value(value: str, data: pd.DataFrame):
+    with pytest.raises(ParsingError, match="A text value must be quoted"):
+        data.esql.query(f"SELECT g WHERE txt = {value}")
+
+
+@pytest.mark.parametrize(("written", "expected"), [("2", ["y"]), ("2.0", ["y"])])
+def test_a_number_column_takes_a_number_however_it_is_written(written: str, expected: list, data: pd.DataFrame):
+    assert list(data.esql.query(f"SELECT g WHERE n = {written}")["g"]) == expected
+
+
+@pytest.mark.parametrize("value", ["'2'", "two", "true"])
+def test_a_number_column_refuses_a_value_that_is_not_a_number(value: str, data: pd.DataFrame):
+    with pytest.raises(ParsingError, match="Invalid value"):
+        data.esql.query(f"SELECT g WHERE n = {value}")
+
+
+###############################################################################
+# The same rules in SUCH THAT
+###############################################################################
+def test_the_value_rules_hold_in_such_that_too(data: pd.DataFrame):
+    """`_parse_condition_value` serves both clauses, so a fix in one is a fix in both. Asserted
+    rather than assumed, since the two clauses reach it by different paths."""
+    with pytest.raises(ParsingError, match="compares against true or false"):
+        data.esql.query("SELECT g, g1.n.sum OVER g1 SUCH THAT g1.flag = 1")
+    with pytest.raises(ParsingError, match="Invalid date"):
+        data.esql.query("SELECT g, g1.n.sum OVER g1 SUCH THAT g1.dt = 'hello'")

--- a/tests/parser/test_util.py
+++ b/tests/parser/test_util.py
@@ -376,24 +376,27 @@ def test_parse_where_clause_raises_error_for_invalid_values(column_dtypes: dict[
     """Two refusals live here, and they are answered at different points. `cust > 'Dan'` and
     `credit > true` are refused for the *operator*, before the value is read at all, because ordering
     a text or boolean column means nothing (`OPERATOR_DTYPES`). The rest are refused for the
-    *value*: the operator applies, and `123` is not something a text column holds."""
-    invalid_values = [
-        "cust = 123",
-        "cust = 12.3",
-        "cust = True",
-        "cust = False",
-        "cust > 'Dan'",
-        "quant == '12'",
-        "month != true",
-        "credit > true",
-    ]
-    for invalid_value in invalid_values:
+    *value*: the operator applies, and `123` is not something a text column holds.
+
+    The message names which of the two it was, since they call for different fixes: change the
+    operator, or write the value the way that column's family is written."""
+    refusals = {
+        "cust = 123": "A text value must be quoted",
+        "cust = 12.3": "A text value must be quoted",
+        "cust = True": "A text value must be quoted",
+        "cust = False": "A text value must be quoted",
+        "cust > 'Dan'": "does not apply to a string column",
+        "quant == '12'": "Invalid value",
+        "month != true": "Invalid value",
+        "credit > true": "does not apply to a boolean column",
+        "credit = 1": "compares against true or false",
+        "date = 'hello'": "Invalid date",
+    }
+    for invalid_value, expected in refusals.items():
         with pytest.raises(ParsingError) as parsingError:
             parse_where_clause(where_clause=invalid_value, column_dtypes=column_dtypes)
-        assert parsingError.value.error_type == ParsingErrorType.WHERE_CLAUSE and any(
-            error in parsingError.value.message
-            for error in ["Invalid value", "Invalid column reference", "does not apply to"]
-        )
+        assert parsingError.value.error_type == ParsingErrorType.WHERE_CLAUSE
+        assert expected in parsingError.value.message, invalid_value
 
 
 def test_parse_where_clause_raises_error_for_double_logical_operators(column_dtypes: dict[str, np.dtype]):

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
`_parse_condition_value` chose its coercion with a chain of pandas dtype predicates — one chain for ordering, a near-identical one for equality — and both ended by asking whether the column was numeric. Two families answer that wrongly.

| written | did | does |
|---|---|---|
| `credit = 1` | matched the true rows | refused |
| `credit = 0` | matched the false rows | refused |
| `credit = 5` | matched nothing, no error | refused |
| `credit = 'true'` | refused | refused |
| `date = 'hello'` | matched nothing, no error | refused |
| `date != 'hello'` | matched **everything**, no error | refused |

A bool column is numeric to pandas, so a boolean fell into the numeric branch and `1` became the value. Object dtype is a *string* dtype to pandas, so any quoted text fell into the text branch and reached a date column as a string, comparing unequal to every date.

**Both are the same failure mode: an answer instead of an error.** Nothing raised. `credit = 1` looks like it worked and did something defensible; `date != 'hello'` returned the whole table. A reader of either result cannot tell a real answer from a misread query.

## The fix

One dispatch on `dtype_family`, which G3 had already made the single definition of the four families. Ordering and equality no longer have a chain each — the value is read as the column's family, and the operator only decides whether ordering is allowed at all, which the `OPERATOR_DTYPES` gate settled earlier in the function. `CONTAINS` stays the one exception, since its value is a substring rather than a value of the column's kind.

The released shape: **`OPERATOR_DTYPES` says whether the operator applies, `dtype_family` says how to read the value.** Neither question is now answered by asking pandas about a dtype in the middle of the other.

Error messages name which question refused the query, because the fixes differ: `'>' does not apply to a string column` means change the operator; `A text value must be quoted` means write the value differently. The existing catch-all test went from asserting *some* error to asserting *which*, over all ten cases.

## Verification

348 tests (was 319). `tests/parser/test_condition_values.py` covers all four families in WHERE and SUCH THAT. Tamper-checked: restoring the numeric fallback for bools fails 7, letting a date take any quoted text fails 8, letting a text column take an unquoted word fails 4.

`public/docs/syntax.md` gains the per-family value table beside the operator table G3 added.

No export changed, so no portfolio guard fires. Worth a glance at the curated examples: a query spelling a boolean as `= 1` would now be a parsing error rather than a quiet result, and `esql-smoke` catches it if one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)