### PR TITLE
v1.13.0: ORDER BY takes named sort terms, aggregates included (H3)

### DIFF
--- a/.claude/status.md
+++ b/.claude/status.md
@@ -261,7 +261,7 @@ H1 shipped; see the settled record. What it leaves open:
   the docs show side by side. Doing them separately means paying that twice, and `esql-smoke` catches
   a partial migration either way.
 
-- [ ] **H3. `ORDER BY` cannot sort by an aggregate.** Filed from portfolio 2026-07-29.
+- [x] **H3. `ORDER BY` cannot sort by an aggregate.** Filed from portfolio 2026-07-29.
   `SELECT song, position.count ORDER BY position.count` raises `[ORDER_BY_CLAUSE] Invalid value`, and
   `ORDER BY 2` raises "out of range of the 1 grouping attributes" — confirming the index counts only
   SELECT's plain columns, so an aggregate is unreachable by either spelling.
@@ -275,6 +275,11 @@ H1 shipped; see the settled record. What it leaves open:
   Whether it extends the index to cover SELECT's full term list or takes the aggregate by name is
   this repo's call; the grammar's `grouping_attribute_index` slot kind would need to change either
   way, which makes it a `slot_kinds`/`accepts` change and therefore visible downstream by design.
+
+  **Shipped in v1.13.0**, by name. The choice was forced rather than preferred: `ORDER BY n` sorts by
+  the *first n* grouping attributes, not the nth, so an index extended over SELECT's full term list
+  still always begins at the first grouping attribute and can never sort by an aggregate alone. The
+  filing offered the two as alternatives; only one of them works. See that entry in the settled record.
 
 - [x] **H2. Rename the unbuilt semi-join.** `CONTAINS` now names the substring operator H1 shipped,
   so the grain-bridging semi-join in the settled record below could not keep that name. Decided
@@ -944,6 +949,62 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   **Portfolio-side follow-up: none, but worth a look at the curated examples.** No export changed.
   Any query spelling a boolean as `= 1` or comparing a date against non-date text would now be a
   parsing error rather than a quiet result, and `esql-smoke` catches it if one exists.
+
+## v1.13.0 — ORDER BY takes named terms, aggregates included (2026-07-30)
+
+- [x] **H3.** `SELECT song, position.count ORDER BY -position.count` answers "which did they play
+  most", which the language could not express at all. Bumped `1.12.0 -> 1.13.0`; the gate is green at
+  **376 tests** (was 348).
+
+  ```sh
+  ORDER BY song                    -- alphabetically
+  ORDER BY -position.count         -- most played first
+  ORDER BY -position.count, song   -- most played first, ties broken alphabetically
+  ORDER BY 2                       -- unchanged: the first two grouping attributes
+  ```
+
+  **The filing offered two options and only one of them works.** It asked whether to extend the index
+  over SELECT's full term list or take the aggregate by name. `ORDER BY n` does not mean "the nth
+  attribute", it means "**the first n** attributes, in order" -- so an extended index still always
+  begins at the first grouping attribute, and `SELECT song, position.count ORDER BY 2` would sort by
+  song and then by the count, never by the count alone. The motivating query stays unreachable under
+  that option however far the number is widened. Found by reading `order_by_sort`, not by assuming
+  the index meant what an index usually means.
+
+  **The integer stays, as sugar over the general form.** `ORDER BY 2` parses into the same
+  `list[SortTerm]` the term list produces, so there is one thing to sort by and one place that knows
+  what descending means. Nothing downstream knows there are two spellings, all 13 curated examples
+  keep working, and the migration H4 will pay for anyway does not have to be paid twice.
+
+  **`-` for descending rather than `DESC`.** ESQL already spelled descending with a sign
+  (`ORDER BY -2`), so this adds no keyword and leaves one way to say it. `ASC`/`DESC` was the
+  alternative and was declined for that reason: it would have left `-2` as a second, inconsistent
+  spelling of the same thing.
+
+  **A term must be projected.** Stricter than SQL, which can order by a column it does not return,
+  and forced by grouping: a column that is neither grouped on nor aggregated has no single value in
+  an output row. The refusal lists the terms that were available, since the answer is already in the
+  query.
+
+  **One sort pass per term, innermost first,** rather than one pass over a tuple key. Python's sort
+  is stable, so each pass preserves what the previous ones established, and that is what lets each
+  term carry its own direction -- `reverse` on a tuple key flips every key at once, so
+  `-position.count, song` is not expressible that way.
+
+  **Also corrected: `grouping_attribute_index`'s published description was wrong.** It said "a
+  1-based index into the SELECT grouping attributes", which is what the name suggests and not what
+  the parser does. Same shape as J5: a `slot_kinds` string that nothing bound to behavior. It now
+  says first-N rather than Nth, and `test_the_index_counts_grouping_attributes_not_select_terms_as_described`
+  binds it.
+
+  Covered by `tests/execution/test_order_by_terms.py` (21 tests) through the public accessor.
+  Verified the guards bite: applying the keys outermost-first fails 6, using one direction for every
+  key fails 2, accepting any word as a term fails 6, and ignoring the minus sign fails 9.
+
+  **Portfolio-side follow-up: the `unhandledSlotKinds` check will fire, by design.** `sort_term` is a
+  new slot kind and `ORDER BY`'s `accepts` grew, which is exactly the channel Stream G built for this.
+  Its caret menu can now offer something in ORDER BY for the first time: the SELECT terms of the query
+  in hand, which is a list it already has. `ORDER BY`'s `separator` also changed from `null` to `","`.
 
 ## 3. Engine-side prep for the ESQL demo
 

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -20,6 +20,7 @@ The per-clause rules this document explains in prose are also available machine-
   - [Entry values](#entry-values)
 - [HAVING](#having)
 - [ORDER BY](#order-by)
+  - [The number shorthand](#the-number-shorthand)
 
 
 ## Structure
@@ -268,16 +269,29 @@ The following is also a valid HAVING clause, assuming the groups `g1` and `g2` a
 
 ## ORDER BY
 
-The ORDER BY clause determines the order of the rows in the outputted table. It should be a number from 0 up to the amount of grouping attributes in the [SELECT](#select) clause, though `ORDER BY 0` will produce the same result as if you omitted the ORDER BY clause from the query. 
+The ORDER BY clause determines the order of the rows in the outputted table. It takes a comma-separated list of [SELECT](#select) terms to sort by, outermost first. A term is a grouping attribute or an aggregate, and a `-` in front of it sorts that term descending:
 
-ORDER BY will order rows alphabetically or numerically (lowest to highest), starting with the first grouping attribute defined in the SELECT clause and continuing in the order they were defined. If value is 1, it will sort the rows by the first grouping attribute. If the value is 2, it will sort the first attribute and then sort the second attribute while maintaining the order or the first. This can repeat for each possible grouping attribute. Define attributes in the SELECT clause in the order you want them to be sorted.
+```sh
+ORDER BY song                    -- alphabetically by song
+ORDER BY -position.count         -- most played first
+ORDER BY -position.count, song   -- most played first, ties broken alphabetically
+```
 
-If you would like to sort the data in reverse order (Z --> A or highest to lowest), you can mark the ORDER BY value as a negative number. This negative number still cannot be outside the range of the grouping attributes.
+Each term carries its own direction, so `ORDER BY -position.count, song` runs the count down and the song up.
 
-If `cust` and `prod` were the grouping attributes in the SELECT clause, the following would be a valid ORDER BY clause:
+A term must be something the query returns. This is stricter than SQL, where ORDER BY can name a column the query does not select, and grouping is why: a column that is neither a grouping attribute nor inside an aggregate has no single value in an output row to sort by. Naming one is a parsing error that lists the terms available.
 
-`ORDER BY 2`
+Sorting is alphabetical for text and low-to-high for numbers and dates. A row with no value for a term (an aggregate whose [SUCH THAT](#such-that) section matched nothing) sorts last.
 
-To sort it in the reverse order, you would instead write:
+### The number shorthand
 
-`ORDER BY -2`
+A single number is shorthand for the first N grouping attributes, in the order the SELECT clause declares them. It is *first N*, not the Nth:
+
+| written | means |
+|---|---|
+| `ORDER BY 1` | sort by the first grouping attribute |
+| `ORDER BY 2` | sort by the first, then the second |
+| `ORDER BY -2` | the same two, both descending |
+| `ORDER BY 0` | no sort, the same as omitting the clause |
+
+The number can never reach an aggregate, however large it is, because the sort it describes always begins at the first grouping attribute. That is what the term list above is for. If `cust` and `prod` are the grouping attributes, `ORDER BY 2` and `ORDER BY cust, prod` are the same query.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.12.0"
+version = "1.13.0"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/esql/execution/algorithms.py
+++ b/src/esql/execution/algorithms.py
@@ -11,6 +11,7 @@ from esql.parser.types import (
     ParsedSelectClause,
     ParsedSuchThatClause,
     ParsedWhereClause,
+    SortTerm,
     aggregate_key,
 )
 from esql.parser.util import find_group_in_such_that_section
@@ -403,17 +404,21 @@ def _sort_key(value):
 
 
 def order_by_sort(
-    projected_table: list[dict[str, str | int | bool | date]], order_by: int, grouping_attributes: list[str]
+    projected_table: list[dict[str, str | int | bool | date]], order_by: list[SortTerm]
 ) -> list[dict[str, str | int | bool | date]]:
-    if order_by > 0:
-        grouping_attribute_sort_keys = tuple(grouping_attributes[:order_by])
+    """Sort the projected rows by each term, outermost first.
+
+    One pass per term, applied from the innermost key outwards, which is the standard way to get a
+    multi-key sort where the keys run in different directions: Python's sort is stable, so each pass
+    keeps the order the previous ones established among rows it considers equal. A single tuple key
+    cannot do that, because `reverse` there flips every key at once.
+
+    A term is a projected label, so an aggregate sorts exactly like a grouping attribute -- by the
+    time the rows reach here the difference has already been projected away.
+    """
+    for sort_term in reversed(order_by):
         projected_table.sort(
-            key=lambda row: tuple(_sort_key(row.get(attribute)) for attribute in grouping_attribute_sort_keys)
-        )
-    elif order_by < 0:
-        grouping_attribute_sort_keys = tuple(grouping_attributes[: abs(order_by)])
-        projected_table.sort(
-            key=lambda row: tuple(_sort_key(row.get(attribute)) for attribute in grouping_attribute_sort_keys),
-            reverse=True,
+            key=lambda row, term=sort_term["term"]: _sort_key(row.get(term)),
+            reverse=sort_term["descending"],
         )
     return projected_table

--- a/src/esql/execution/execute.py
+++ b/src/esql/execution/execute.py
@@ -28,7 +28,6 @@ def execute(parsed_query: ParsedQuery, decimal_places: int) -> pd.DataFrame:
     ordered_table = algorithms.order_by_sort(
         projected_table=projected_table,
         order_by=parsed_query["order_by"],
-        grouping_attributes=parsed_query["select"]["grouping_attributes"],
     )
 
     return pd.DataFrame(ordered_table)

--- a/src/esql/grammar.py
+++ b/src/esql/grammar.py
@@ -45,8 +45,16 @@ SLOT_KINDS = {
         "row rather than to a constant."
     ),
     "aggregate_condition": "An aggregate compared against a number.",
+    "sort_term": (
+        "A SELECT term to sort the output by, either a grouping attribute or an aggregate, "
+        "optionally prefixed with `-` to sort it descending. A term must be one the query "
+        "projects, since the sort runs over the returned rows."
+    ),
     "grouping_attribute_index": (
-        "A 1-based index into the SELECT grouping attributes. Negative reverses the sort."
+        "Shorthand for a sort term list: a count N of the SELECT grouping attributes, meaning sort "
+        "by the first N of them in the order SELECT declares them. It is *first N*, not the Nth, so "
+        "`2` sorts by the first attribute and then the second. Negative runs them all descending. "
+        "This cannot reach an aggregate at any value, which is what `sort_term` is for."
     ),
 }
 
@@ -101,10 +109,14 @@ CLAUSES = {
     "ORDER BY": {
         "required": False,
         "requires": [],
-        "separator": None,
-        "accepts": ["grouping_attribute_index"],
+        "separator": ",",
+        "accepts": ["sort_term", "grouping_attribute_index"],
         "operators": [],
-        "summary": "Sorts by one of the SELECT grouping attributes, chosen by 1-based position.",
+        "summary": (
+            "Sorts the output by a list of SELECT terms, outermost first, each optionally prefixed "
+            "with `-` for descending. A bare number is shorthand for the first N grouping "
+            "attributes. Omitted, the row order is unspecified."
+        ),
     },
 }
 

--- a/src/esql/parser/parse.py
+++ b/src/esql/parser/parse.py
@@ -87,7 +87,8 @@ def _build_parsed_query(data: pd.DataFrame, query: str) -> ParsedQuery:
 
     order_by_clause = parse_order_by_clause(
         order_by_clause=keyword_clauses["ORDER BY"],
-        number_of_select_grouping_attributes=len(parsed_select_clause["grouping_attributes"]),
+        grouping_attributes=parsed_select_clause["grouping_attributes"],
+        select_items_in_order=parsed_select_clause["select_items_in_order"],
     )
 
     return ParsedQuery(

--- a/src/esql/parser/types.py
+++ b/src/esql/parser/types.py
@@ -64,6 +64,22 @@ class EntryValue(TypedDict):
     delta: float
 
 
+class SortTerm(TypedDict):
+    """One key of the output sort: a SELECT term, and which way to run it.
+
+    `term` is a projected label, so it is the key a projected row is already indexed by, whether it
+    names a grouping attribute (`song`) or an aggregate (`position.count`, `g1.quant.sum`). That is
+    what lets execution sort by an aggregate at all: by the time the sort runs, an aggregate is just
+    another column of the row.
+
+    The integer form (`ORDER BY 2`) parses into a list of these rather than staying a number, so
+    there is one thing to sort by and one place that knows what descending means.
+    """
+
+    term: str
+    descending: bool
+
+
 class SimpleCondition(TypedDict):
     column: str
     operator: str
@@ -149,5 +165,5 @@ class ParsedQuery(TypedDict):
     where: ParsedWhereClause | None
     such_that: ParsedSuchThatClause | None
     having: ParsedHavingClause | None
-    order_by: int
+    order_by: list[SortTerm]
     aggregates: AggregatesDict

--- a/src/esql/parser/util.py
+++ b/src/esql/parser/util.py
@@ -27,6 +27,7 @@ from esql.parser.types import (
     SemiJoinCondition,
     SimpleCondition,
     SimpleGroupCondition,
+    SortTerm,
     aggregate_key,
 )
 
@@ -676,23 +677,87 @@ def _parse_aggregate_condition(
 ###########################################################################
 # ORDER BY Clause Parsing
 ###########################################################################
-def parse_order_by_clause(order_by_clause: str | None, number_of_select_grouping_attributes: int):
+def parse_order_by_clause(
+    order_by_clause: str | None, grouping_attributes: list[str], select_items_in_order: list[str]
+) -> list[SortTerm]:
+    """Read ORDER BY as the list of keys the output is sorted by, outermost first.
+
+    Two spellings, one result. A **term list** names SELECT terms and is the general form:
+    `ORDER BY -position.count, song` sorts by the count descending, then by song. An **integer** is
+    shorthand for the first N grouping attributes, which is what ESQL had before terms existed:
+    `ORDER BY 2` is `ORDER BY <first>, <second>` and a negative runs them all descending. The
+    integer parses into the same list, so nothing downstream knows there are two spellings.
+
+    A term has to be something SELECT projects, because the sort runs over projected rows and a
+    column that was never projected holds no value there. That is stricter than SQL, where ORDER BY
+    can reach a column the query does not return, and it is forced by grouping: a column that is
+    neither grouped on nor aggregated has no single value per output row to sort by.
+    """
     if order_by_clause is None:
-        return 0
+        return []
+    written = order_by_clause.strip()
+    if not written:
+        return []
+
+    index = _as_integer(written)
+    if index is not None:
+        return _sort_terms_from_index(index, written, grouping_attributes)
+
+    terms = []
+    for part in written.split(","):
+        written_term = part.strip()
+        descending = written_term.startswith("-")
+        if descending:
+            written_term = written_term[1:].strip()
+        if not written_term:
+            raise ParsingError(
+                ParsingErrorType.ORDER_BY_CLAUSE, f"Empty sort term in: '{written}'", token=order_by_clause
+            )
+        terms.append(SortTerm(term=_resolve_sort_term(written_term, select_items_in_order), descending=descending))
+    return terms
+
+
+def _as_integer(written: str) -> int | None:
+    """`written` as an int, or None when it is not one. None means "read it as a term list"."""
     try:
-        order_value = int(order_by_clause.strip())
+        return int(written)
     except ValueError:
-        raise ParsingError(
-            ParsingErrorType.ORDER_BY_CLAUSE, f"Invalid value: '{order_by_clause}'", token=order_by_clause
-        ) from None
-    if order_value > number_of_select_grouping_attributes or order_value < -number_of_select_grouping_attributes:
+        return None
+
+
+def _sort_terms_from_index(index: int, written: str, grouping_attributes: list[str]) -> list[SortTerm]:
+    """The integer shorthand: the first `|index|` grouping attributes, descending if it is negative.
+
+    Note this is *first N*, not *the Nth*. `ORDER BY 2` sorts by the first grouping attribute and
+    then by the second, which is why it cannot reach an aggregate however far it is extended: the
+    sort it describes always begins at the first grouping attribute. That is what the term list is
+    for, and why widening this number was not the fix.
+    """
+    if abs(index) > len(grouping_attributes):
         raise ParsingError(
             ParsingErrorType.ORDER_BY_CLAUSE,
-            f"{order_by_clause.strip()} out of range of the {number_of_select_grouping_attributes} "
+            f"{written} out of range of the {len(grouping_attributes)} "
             "grouping attributes provided in the select clause.",
-            token=order_by_clause,
+            token=written,
         )
-    return order_value
+    return [SortTerm(term=attribute, descending=index < 0) for attribute in grouping_attributes[: abs(index)]]
+
+
+def _resolve_sort_term(written_term: str, select_items_in_order: list[str]) -> str:
+    """The projected label `written_term` names, case-insensitively, or a ParsingError naming what is
+    available. Sorting by something the query does not return is a mistake worth reporting with the
+    list of what it could have meant, since the terms are right there in the query."""
+    if written_term in select_items_in_order:
+        return written_term
+    matches = [item for item in select_items_in_order if item.lower() == written_term.lower()]
+    if len(matches) == 1:
+        return matches[0]
+    raise ParsingError(
+        ParsingErrorType.ORDER_BY_CLAUSE,
+        f"'{written_term}' is not a SELECT term, so there is nothing to sort by. "
+        f"Available: {', '.join(select_items_in_order)}.",
+        token=written_term,
+    )
 
 
 ###########################################################################

--- a/tests/execution/test_execution_unit.py
+++ b/tests/execution/test_execution_unit.py
@@ -2,7 +2,16 @@ import pytest
 
 from esql.execution.algorithms import order_by_sort, project_select_attributes
 from esql.execution.grouped_row import GroupedRow
-from esql.parser.types import AggregatesDict, ParsedSelectClause
+from esql.parser.types import AggregatesDict, ParsedSelectClause, SortTerm
+
+
+def _first(attributes: list[str], count: int, descending: bool = False) -> list[SortTerm]:
+    """The sort `ORDER BY <count>` describes: the first `count` grouping attributes, in order.
+
+    These tests predate named sort terms and were written against the integer form, so this keeps
+    them saying what they said. The parser produces the same list from `ORDER BY <count>`.
+    """
+    return [SortTerm(term=attribute, descending=descending) for attribute in attributes[:count]]
 
 
 def test_order_by_sort():
@@ -55,9 +64,9 @@ def test_order_by_sort():
         {"cust": "Wally", "prod": "Cherry", "round": 527.54, "sum": 63832},
         {"cust": "Wally", "prod": "Ham", "round": 533.85, "sum": 59257},
     ]
-    assert order_by_sort(projected_table=order_by_0, order_by=0, grouping_attributes=grouping_attributes) == order_by_0
-    assert order_by_sort(projected_table=order_by_0, order_by=1, grouping_attributes=grouping_attributes) == order_by_1
-    assert order_by_sort(projected_table=order_by_0, order_by=2, grouping_attributes=grouping_attributes) == order_by_2
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 0)) == order_by_0
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 1)) == order_by_1
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 2)) == order_by_2
 
 
 def test_order_by_sort_works_when_grouping_attributes_are_not_at_the_front():
@@ -95,9 +104,9 @@ def test_order_by_sort_works_when_grouping_attributes_are_not_at_the_front():
         {"round": 527.54, "cust": "Wally", "sum": 63832, "prod": "Cherry"},
         {"round": 533.85, "cust": "Wally", "sum": 59257, "prod": "Ham"},
     ]
-    assert order_by_sort(projected_table=order_by_0, order_by=0, grouping_attributes=grouping_attributes) == order_by_0
-    assert order_by_sort(projected_table=order_by_0, order_by=1, grouping_attributes=grouping_attributes) == order_by_1
-    assert order_by_sort(projected_table=order_by_0, order_by=2, grouping_attributes=grouping_attributes) == order_by_2
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 0)) == order_by_0
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 1)) == order_by_1
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 2)) == order_by_2
 
 
 def test_order_by_sort_works_with_numbers():
@@ -129,9 +138,9 @@ def test_order_by_sort_works_with_numbers():
         {"round": 520, "sum": 58262},
         {"round": 520, "sum": 67995},
     ]
-    assert order_by_sort(projected_table=order_by_0, order_by=0, grouping_attributes=grouping_attributes) == order_by_0
-    assert order_by_sort(projected_table=order_by_0, order_by=1, grouping_attributes=grouping_attributes) == order_by_1
-    assert order_by_sort(projected_table=order_by_0, order_by=2, grouping_attributes=grouping_attributes) == order_by_2
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 0)) == order_by_0
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 1)) == order_by_1
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 2)) == order_by_2
 
 
 def test_order_by_sort_with_numeric_attribute():
@@ -175,13 +184,13 @@ def test_order_by_sort_with_numeric_attribute():
         {"cust": "Boo", "num": 8},
         {"cust": "Boo", "num": 6},
     ]
-    assert order_by_sort(projected_table=order_by_0, order_by=0, grouping_attributes=grouping_attributes) == order_by_0
+    assert order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 0)) == order_by_0
     assert (
-        order_by_sort(projected_table=order_by_0, order_by=-1, grouping_attributes=grouping_attributes)
+        order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 1, descending=True))
         == order_by_neg_1
     )
     assert (
-        order_by_sort(projected_table=order_by_0, order_by=-2, grouping_attributes=grouping_attributes)
+        order_by_sort(projected_table=order_by_0, order_by=_first(grouping_attributes, 2, descending=True))
         == order_by_neg_2
     )
 

--- a/tests/execution/test_order_by_terms.py
+++ b/tests/execution/test_order_by_terms.py
@@ -1,0 +1,157 @@
+"""Sorting the output by named SELECT terms, aggregates included (H3).
+
+Before this, ORDER BY took one number meaning "the first N grouping attributes", so the second half
+of the first question anyone asks of a dataset -- having counted something, sort by the count --
+could not be written at all. Widening the number would not have fixed it: the sort it describes
+always starts at the first grouping attribute, so `SELECT song, song.count ORDER BY 2` would sort by
+song and then by the count, never by the count alone.
+
+These go through the public accessor, since the point is what a query can now express.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pandas as pd
+import pytest
+
+from esql.parser.error import ParsingError
+
+
+@pytest.fixture
+def plays() -> pd.DataFrame:
+    """Three songs with 3, 2 and 2 plays: enough for a tie, so the second sort key has work to do."""
+    return pd.DataFrame(
+        {
+            "song": ["Truckin", "Truckin", "Truckin", "Dark Star", "Dark Star", "Sugaree", "Sugaree"],
+            "venue": ["a", "b", "c", "a", "b", "a", "b"],
+            "seconds": [10, 20, 30, 40, 50, 60, 70],
+        }
+    )
+
+
+def _rows(result: pd.DataFrame, column: str = "song") -> list:
+    return list(result[column])
+
+
+###############################################################################
+# The motivating query
+###############################################################################
+def test_sorting_by_an_aggregate_descending(plays: pd.DataFrame):
+    """"Which did they play most" -- the query H3 was filed for."""
+    result = plays.esql.query("SELECT song, seconds.count ORDER BY -seconds.count")
+    assert _rows(result)[0] == "Truckin"
+    assert list(result["seconds.count"]) == [3, 2, 2]
+
+
+def test_sorting_by_an_aggregate_ascending(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT song, seconds.count ORDER BY seconds.count")
+    assert list(result["seconds.count"]) == [2, 2, 3]
+
+
+def test_a_second_term_breaks_the_tie(plays: pd.DataFrame):
+    """Two songs have 2 plays each, so the count alone does not determine the order and `song` does."""
+    result = plays.esql.query("SELECT song, seconds.count ORDER BY -seconds.count, song")
+    assert _rows(result) == ["Truckin", "Dark Star", "Sugaree"]
+
+
+def test_each_term_carries_its_own_direction(plays: pd.DataFrame):
+    """The count descending, the tie broken descending: the pair a single reversed sort cannot make,
+    since one `reverse` flips every key at once."""
+    ascending_name = plays.esql.query("SELECT song, seconds.count ORDER BY -seconds.count, song")
+    descending_name = plays.esql.query("SELECT song, seconds.count ORDER BY -seconds.count, -song")
+    assert _rows(ascending_name) == ["Truckin", "Dark Star", "Sugaree"]
+    assert _rows(descending_name) == ["Truckin", "Sugaree", "Dark Star"]
+
+
+def test_sorting_by_a_group_specific_aggregate(plays: pd.DataFrame):
+    result = plays.esql.query(
+        "SELECT song, g1.seconds.sum OVER g1 SUCH THAT g1.venue = 'a' ORDER BY -g1.seconds.sum"
+    )
+    assert _rows(result) == ["Sugaree", "Dark Star", "Truckin"]
+
+
+###############################################################################
+# Named grouping attributes
+###############################################################################
+def test_sorting_by_a_named_grouping_attribute(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT song, seconds.count ORDER BY song")
+    assert _rows(result) == ["Dark Star", "Sugaree", "Truckin"]
+
+
+def test_sorting_by_a_named_attribute_descending(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT song, seconds.count ORDER BY -song")
+    assert _rows(result) == ["Truckin", "Sugaree", "Dark Star"]
+
+
+def test_a_term_is_resolved_case_insensitively(plays: pd.DataFrame):
+    """Identifiers fold like everywhere else since v1.9.0, and an aggregate's function does too."""
+    result = plays.esql.query("SELECT song, seconds.count ORDER BY -SECONDS.COUNT")
+    assert _rows(result)[0] == "Truckin"
+
+
+###############################################################################
+# The integer shorthand still means what it meant
+###############################################################################
+def test_the_integer_form_sorts_by_the_first_n_attributes(plays: pd.DataFrame):
+    by_number = plays.esql.query("SELECT song, venue, seconds.sum ORDER BY 2")
+    by_name = plays.esql.query("SELECT song, venue, seconds.sum ORDER BY song, venue")
+    assert by_number.equals(by_name)
+
+
+def test_a_negative_integer_runs_every_attribute_descending(plays: pd.DataFrame):
+    by_number = plays.esql.query("SELECT song, venue, seconds.sum ORDER BY -2")
+    by_name = plays.esql.query("SELECT song, venue, seconds.sum ORDER BY -song, -venue")
+    assert by_number.equals(by_name)
+
+
+def test_zero_and_an_omitted_clause_agree(plays: pd.DataFrame):
+    assert plays.esql.query("SELECT song, seconds.count ORDER BY 0").equals(
+        plays.esql.query("SELECT song, seconds.count")
+    )
+
+
+###############################################################################
+# Refusals
+###############################################################################
+def test_a_term_the_query_does_not_project_is_refused(plays: pd.DataFrame):
+    """`venue` is a real column, but this query returns no value for it per output row."""
+    with pytest.raises(ParsingError, match="'venue' is not a SELECT term"):
+        plays.esql.query("SELECT song, seconds.count ORDER BY venue")
+
+
+def test_the_refusal_names_what_could_have_been_meant(plays: pd.DataFrame):
+    with pytest.raises(ParsingError, match=re.escape("Available: song, seconds.count")):
+        plays.esql.query("SELECT song, seconds.count ORDER BY venue")
+
+
+def test_an_aggregate_that_is_not_selected_is_refused(plays: pd.DataFrame):
+    """Sorting by an aggregate the query never computes. It is not that the aggregate is illegal,
+    it is that nothing in the output holds it."""
+    with pytest.raises(ParsingError, match="is not a SELECT term"):
+        plays.esql.query("SELECT song, seconds.count ORDER BY seconds.sum")
+
+
+def test_an_index_past_the_grouping_attributes_is_refused(plays: pd.DataFrame):
+    with pytest.raises(ParsingError, match="out of range"):
+        plays.esql.query("SELECT song, seconds.count ORDER BY 2")
+
+
+def test_an_empty_term_is_refused(plays: pd.DataFrame):
+    with pytest.raises(ParsingError, match="Empty sort term"):
+        plays.esql.query("SELECT song, seconds.count ORDER BY song, ")
+
+
+###############################################################################
+# Nulls
+###############################################################################
+def test_a_missing_aggregate_value_sorts_last_ascending():
+    """A group whose SUCH THAT section matched nothing has no value for its aggregate. Ascending, a
+    missing value sorts last rather than raising on a comparison against a number."""
+    data = pd.DataFrame({"song": ["a", "b"], "venue": ["x", "y"], "seconds": [1, 2]})
+    result = data.esql.query(
+        "SELECT song, g1.seconds.sum OVER g1 SUCH THAT g1.venue = 'x' ORDER BY g1.seconds.sum"
+    )
+    assert _rows(result) == ["a", "b"]
+    assert pd.isna(list(result["g1.seconds.sum"])[-1])

--- a/tests/parser/test_grammar.py
+++ b/tests/parser/test_grammar.py
@@ -169,9 +169,33 @@ def test_clause_order_follows_the_described_keyword_order(data: pd.DataFrame):
         data.esql.validate("SELECT cust, quant.sum HAVING quant.sum > 0 WHERE quant > 0")
 
 
-@pytest.mark.parametrize("clause", ["SELECT", "OVER", "SUCH THAT"])
+@pytest.mark.parametrize("clause", ["SELECT", "OVER", "SUCH THAT", "ORDER BY"])
 def test_comma_separated_clauses_are_described_as_such(clause: str):
     assert GRAMMAR["clauses"][clause]["separator"] == ","
+
+
+def test_order_by_accepts_both_described_slot_kinds(data: pd.DataFrame):
+    """The two spellings the grammar declares, each run through the parser."""
+    assert GRAMMAR["clauses"]["ORDER BY"]["accepts"] == ["sort_term", "grouping_attribute_index"]
+    data.esql.validate("SELECT cust, quant.sum ORDER BY -quant.sum, cust")  # sort_term
+    data.esql.validate("SELECT cust, quant.sum ORDER BY 1")  # grouping_attribute_index
+
+
+def test_a_sort_term_must_be_projected_as_described(data: pd.DataFrame):
+    assert "must be one the query projects" in GRAMMAR["slot_kinds"]["sort_term"]
+    # `prod` is a column of the frame, but this query does not return it.
+    with pytest.raises(ParsingError, match="is not a SELECT term"):
+        data.esql.validate("SELECT cust, quant.sum ORDER BY prod")
+
+
+def test_the_index_counts_grouping_attributes_not_select_terms_as_described(data: pd.DataFrame):
+    """The number is bounded by the grouping attributes alone, which is exactly why it cannot reach
+    an aggregate: `SELECT cust, quant.sum` has one attribute, so `2` is out of range rather than
+    naming the aggregate."""
+    assert "not the Nth" in GRAMMAR["slot_kinds"]["grouping_attribute_index"]
+    data.esql.validate("SELECT cust, quant.sum ORDER BY 1")
+    with pytest.raises(ParsingError, match="out of range"):
+        data.esql.validate("SELECT cust, quant.sum ORDER BY 2")
 
 
 def test_repeating_a_group_across_such_that_sections_is_rejected(data: pd.DataFrame):

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -16,6 +16,7 @@ from esql.parser.types import (
     ParsedSelectClause,
     SimpleCondition,
     SimpleGroupCondition,
+    SortTerm,
 )
 
 
@@ -104,7 +105,8 @@ def test_get_parsed_query_returns_the_expected_structure(sales_test_data: pd.Dat
         having=GroupAggregateCondition(
             aggregate=GroupAggregate(group="g1", column="quant", function="avg"), operator=">", value=0.5
         ),
-        order_by=1,
+        # `ORDER BY 1` is shorthand for the first grouping attribute, ascending.
+        order_by=[SortTerm(term="cust", descending=False)],
         aggregates=AggregatesDict(
             global_scope=[
                 GlobalAggregate(column="quant", function="avg"),
@@ -145,7 +147,7 @@ def test_get_parsed_query_returns_expected_structure_with_missing_parts(sales_te
         where=None,
         such_that=None,
         having=None,
-        order_by=0,
+        order_by=[],
         aggregates=AggregatesDict(global_scope=[], group_specific=[]),
     )
     assert (

--- a/tests/parser/test_util.py
+++ b/tests/parser/test_util.py
@@ -25,6 +25,7 @@ from esql.parser.types import (
     ParsedWhereClause,
     SimpleCondition,
     SimpleGroupCondition,
+    SortTerm,
 )
 from esql.parser.util import (
     _has_wrapping_parenthesis,
@@ -647,41 +648,94 @@ def test_parse_having_clause_raises_error_for_non_numeric_comparison_value(colum
 ###########################################################################
 # PARSE_ORDER_BY_CLAUSE TESTS
 ###########################################################################
-def test_order_by_clause_returns_expected_structure():
-    parsedOrderByClause = parse_order_by_clause(order_by_clause="3", number_of_select_grouping_attributes=3)
-    expected = 3
-    assert parsedOrderByClause == expected
+ORDER_BY_ATTRIBUTES = ["cust", "prod", "state"]
+ORDER_BY_TERMS = ["cust", "prod", "state", "quant.sum", "g1.quant.avg"]
 
 
-def test_order_by_clause_returns_expected_structure_for_negative_number():
-    parsedOrderByClause = parse_order_by_clause(order_by_clause="-3", number_of_select_grouping_attributes=3)
-    expected = -3
-    assert parsedOrderByClause == expected
-
-
-def test_order_by_clause_raises_error_for_non_number_input():
-    with pytest.raises(ParsingError) as parsingError:
-        parse_order_by_clause(order_by_clause="apple", number_of_select_grouping_attributes=3)
-    assert (
-        parsingError.value.error_type == ParsingErrorType.ORDER_BY_CLAUSE
-        and "Invalid value" in parsingError.value.message
+def _order_by(clause: str | None):
+    return parse_order_by_clause(
+        order_by_clause=clause, grouping_attributes=ORDER_BY_ATTRIBUTES, select_items_in_order=ORDER_BY_TERMS
     )
 
 
-def test_order_by_clause_raises_error_for_non_integer_input():
+def test_order_by_clause_reads_the_integer_as_the_first_n_grouping_attributes():
+    """Not the Nth: `ORDER BY 3` sorts by the first attribute, then the second, then the third."""
+    assert _order_by("3") == [
+        SortTerm(term="cust", descending=False),
+        SortTerm(term="prod", descending=False),
+        SortTerm(term="state", descending=False),
+    ]
+
+
+def test_order_by_clause_reads_a_negative_integer_as_all_of_them_descending():
+    assert _order_by("-3") == [
+        SortTerm(term="cust", descending=True),
+        SortTerm(term="prod", descending=True),
+        SortTerm(term="state", descending=True),
+    ]
+
+
+def test_order_by_clause_reads_a_named_term():
+    assert _order_by("prod") == [SortTerm(term="prod", descending=False)]
+
+
+def test_order_by_clause_reads_an_aggregate_term():
+    assert _order_by("quant.sum") == [SortTerm(term="quant.sum", descending=False)]
+    assert _order_by("g1.quant.avg") == [SortTerm(term="g1.quant.avg", descending=False)]
+
+
+def test_order_by_clause_reads_a_leading_minus_as_descending():
+    assert _order_by("-quant.sum") == [SortTerm(term="quant.sum", descending=True)]
+    assert _order_by("- quant.sum") == [SortTerm(term="quant.sum", descending=True)]
+
+
+def test_order_by_clause_reads_a_list_with_a_direction_per_term():
+    assert _order_by("-quant.sum, cust") == [
+        SortTerm(term="quant.sum", descending=True),
+        SortTerm(term="cust", descending=False),
+    ]
+
+
+def test_order_by_clause_resolves_a_term_case_insensitively():
+    assert _order_by("QUANT.SUM") == [SortTerm(term="quant.sum", descending=False)]
+    assert _order_by("Cust") == [SortTerm(term="cust", descending=False)]
+
+
+def test_order_by_clause_reads_nothing_as_no_sort():
+    assert _order_by(None) == []
+    assert _order_by("0") == []
+
+
+def test_order_by_clause_raises_error_for_a_term_that_is_not_selected():
+    """`quant` is a column of the frame but not a SELECT term, so a projected row holds no value
+    for it. The error names what is available, since the answer is in the query already."""
     with pytest.raises(ParsingError) as parsingError:
-        parse_order_by_clause(order_by_clause="2.3", number_of_select_grouping_attributes=3)
-    assert (
-        parsingError.value.error_type == ParsingErrorType.ORDER_BY_CLAUSE
-        and "Invalid value" in parsingError.value.message
-    )
+        _order_by("quant")
+    assert parsingError.value.error_type == ParsingErrorType.ORDER_BY_CLAUSE
+    assert "is not a SELECT term" in parsingError.value.message
+    assert "quant.sum" in parsingError.value.message
+
+
+def test_order_by_clause_raises_error_for_a_non_integer_number():
+    """`2.3` is not an index and is not a term either, so it is refused as a term."""
+    with pytest.raises(ParsingError) as parsingError:
+        _order_by("2.3")
+    assert parsingError.value.error_type == ParsingErrorType.ORDER_BY_CLAUSE
+    assert "is not a SELECT term" in parsingError.value.message
+
+
+def test_order_by_clause_raises_error_for_an_empty_term_in_a_list():
+    with pytest.raises(ParsingError) as parsingError:
+        _order_by("cust, , prod")
+    assert parsingError.value.error_type == ParsingErrorType.ORDER_BY_CLAUSE
+    assert "Empty sort term" in parsingError.value.message
 
 
 def test_order_by_clause_raises_error_for_out_of_range_inputs():
     out_of_range_values = ["-44", "1001", "-543578", "7"]
     for value in out_of_range_values:
         with pytest.raises(ParsingError) as parsingError:
-            parse_order_by_clause(order_by_clause=value, number_of_select_grouping_attributes=3)
+            _order_by(value)
         assert (
             parsingError.value.error_type == ParsingErrorType.ORDER_BY_CLAUSE
             and f"{value} out of range" in parsingError.value.message

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
`SELECT song, position.count ORDER BY -position.count` answers "which songs did they play most" — the second half of the first question anyone asks of this dataset, and the language could not express it at all.

```sh
ORDER BY song                    -- alphabetically
ORDER BY -position.count         -- most played first
ORDER BY -position.count, song   -- most played first, ties broken alphabetically
ORDER BY 2                       -- unchanged: the first two grouping attributes
```

## The filing offered two options and only one of them works

H3 asked whether to extend the index over SELECT's full term list, or take the aggregate by name. `ORDER BY n` does not mean "the nth attribute" — it means "**the first n**, in order". So an extended index still always begins at the first grouping attribute: `SELECT song, position.count ORDER BY 2` would sort by song and *then* by the count, never by the count alone. The motivating query stays unreachable however far the number is widened.

## Decisions

- **The integer stays, as sugar.** It parses into the same `list[SortTerm]` the term list produces, so there is one thing to sort by and one place that knows what descending means. Nothing downstream knows there are two spellings; all 13 curated examples keep working.
- **`-` rather than `DESC`.** ESQL already spelled descending with a sign (`ORDER BY -2`), so this adds no keyword. `ASC`/`DESC` would have left `-2` as a second, inconsistent spelling of the same thing.
- **A term must be projected.** Stricter than SQL, and forced by grouping: a column neither grouped on nor aggregated has no single value in an output row. The refusal lists what was available.
- **One stable sort pass per term, innermost first.** That is what lets each term carry its own direction — `reverse` on a tuple key flips every key at once, so `-position.count, song` is not expressible that way.

## Also corrected

`grouping_attribute_index`'s published description claimed "a 1-based index into the SELECT grouping attributes", which is what the name suggests and not what the parser does. Same shape as J5: a `slot_kinds` string nothing bound to behavior. It now says first-N, and a test binds it.

## Verification

376 tests (was 348). `tests/execution/test_order_by_terms.py` covers it through the public accessor. Tamper-checked: applying the keys outermost-first fails 6, one direction for every key fails 2, accepting any word as a term fails 6, ignoring the minus sign fails 9.

## Portfolio-side

**The `unhandledSlotKinds` check will fire, by design** — `sort_term` is a new slot kind and `ORDER BY`'s `accepts` grew, which is the channel Stream G built for exactly this. `ORDER BY`'s `separator` also changed from `null` to `","`. The caret menu can now offer something in ORDER BY for the first time: the SELECT terms of the query in hand, a list it already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)