### PR TITLE
v1.14.0 + v1.15.0: bind syntax.md to the grammar (G2), and count rows bare / distinct on a column (H4)

### DIFF
--- a/.claude/status.md
+++ b/.claude/status.md
@@ -216,9 +216,10 @@ clause gaining a rule upstream simply goes unreflected downstream.
 
 ## Stream H — language features
 
-H1 shipped; see the settled record. What it leaves open:
+**Closed 2026-07-30.** H1 (CONTAINS) shipped in v1.3.0, H2 was a rename in the design notes, H3
+(ORDER BY by name) in v1.13.0 and H4 (the two counts) in v1.15.0. What each one settled:
 
-- [ ] **H4. `count` should count rows bare, and count *distinct* on a column.** Filed from portfolio
+- [x] **H4. `count` should count rows bare, and count *distinct* on a column.** Filed from portfolio
   2026-07-29, from a visitor reading a result and being wrong about it in the way the syntax invites.
 
   **What happened.** `SELECT state, city.count` returns 11,963 for CA. That is the row count — CA has
@@ -264,6 +265,12 @@ H1 shipped; see the settled record. What it leaves open:
   rewrite all 13 curated examples, the walkthrough, `songs.structure.json` and every SQL equivalent
   the docs show side by side. Doing them separately means paying that twice, and `esql-smoke` catches
   a partial migration either way.
+
+  **The engine half shipped in v1.15.0**, both decisions taken as filed: `forms` grew the two bare
+  shapes and `any_dtype` narrowed to the column form. See that entry in the settled record. The
+  sequencing note stands for the *portfolio* half, which is where the 13 examples live: nothing
+  downstream has to move until it moves with D1, since a query written the old way still parses --
+  it just answers the distinct count now, which is the one thing to watch for in that migration.
 
 - [x] **H3. `ORDER BY` cannot sort by an aggregate.** Filed from portfolio 2026-07-29.
   `SELECT song, position.count ORDER BY position.count` raises `[ORDER_BY_CLAUSE] Invalid value`, and
@@ -508,7 +515,7 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   `public/docs/syntax.md` section + an ESQL demo example. Pairs with HAS: HAS
   *filters* one grain by another; this *measures* across grains. Design captured now; build parked
   until the datasets/rename plumbing lands.
-- [ ] **mypy clean pass.** 157 errors (159 before v1.9.0, and recorded as 156 until v1.8.0; the count was
+- [ ] **mypy clean pass.** 152 errors (157 before v1.15.0, 159 before v1.9.0, and recorded as 156 until v1.8.0; the count was
   stale at 143 before that because `make typecheck` called
   `uv run mypy`, whose console script does not spawn, so the target errored out before reaching
   mypy; fixed in v1.5.0 to `uv run python -m mypy`, the form every other target uses). All from
@@ -1049,6 +1056,93 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   **Portfolio-side follow-up: none.** No export changed and no new name. Worth knowing that the
   reference cards portfolio renders are its own copy of this material, and this guard covers only
   the doc in this repo. The same marker idea is available there if its cards are ever worth binding.
+
+## v1.15.0 — `count` counts rows, `column.count` counts distinct (2026-07-30)
+
+- [x] **H4, which closes Stream H.** `SELECT state, count` is the row count, and `state.count` is now
+  the number of distinct states. Bumped `1.14.0 -> 1.15.0`; the gate is green at **423 tests**
+  (was 386).
+
+  ```sh
+  SELECT cust, count              -- how many rows this customer has
+  SELECT cust, prod.count         -- how many distinct products
+  SELECT cust, g1.count OVER g1 SUCH THAT g1.state = 'NY'   -- how many rows in the group
+  ```
+
+  **What was wrong was an answer, not an error**, which is the same shape as K3 and J4. `city.count`,
+  `song.count` and `position.count` all returned 11,963 for CA, the row count, because the column in
+  `X.count` carried no meaning except its nullness. Under a clause that groups automatically,
+  `city.count` reads as "the cities, counted" and CA has 61 of those. Nothing raised, and nothing
+  could: the query was answerable, just not the question the syntax spelled.
+
+  **The root cause was a missing spelling.** ESQL had no `COUNT(*)`, so every row count borrowed a
+  column, and dot-notation turned the borrowed name into an apparent meaning. Giving the row count a
+  form with no column removes the misleading one rather than documenting it: after this there is no
+  way to write a row count that names an irrelevant column, which is what made the migration worth
+  paying for.
+
+  Decisions worth keeping:
+
+  - **`count` is reserved in SELECT, above a column of the same name.** The alternative was to let
+    the frame decide, and then the same query means different things over different data. A column
+    called `count` stays reachable everywhere it cannot be confused with the function: `count.count`,
+    `count.sum`, `WHERE count > 5`, `ORDER BY count`. Only the bare word in a grouping-attribute slot
+    is spoken for, and only `count` -- a column named `sum` is still projectable, because the check
+    that refuses `SELECT cust, sum` runs *after* the word fails to name a column.
+  - **`g1.count` beats a column named `g1`.** Same tiebreak, decided the other way round from a
+    coin-flip: the group is declared by the query itself a few words earlier, in OVER, which makes it
+    the more deliberate of the two readings.
+  - **`sum / count` is no longer `avg`, and that is not a bug to fix.** It is a SQL identity, not a
+    law; with `count` defined as distinct it does not hold, and `avg` keeps its own definition over
+    rows. Pinned by a test so nobody restores it by "fixing" avg.
+  - **A distinct count skips blanks; a row count does not.** A missing value is not a value (SQL's
+    `COUNT(DISTINCT x)` agrees), while a blank cell makes a row no less of a row. A column that is
+    blank everywhere has *no* count rather than zero, the same as any aggregate with nothing to
+    compute.
+  - **Both bare forms are published literally**, as `count` and `group.count` in
+    `GRAMMAR["aggregates"]["forms"]`, rather than as a `function` pattern. Only `count` takes the
+    form, and a pattern would promise `sum` does too.
+  - **`any_dtype` narrowed rather than moved.** It answers "which functions may a non-numeric
+    *column* be given", and the bare form gives no column, so it sits outside the rule instead of
+    becoming an exception to it. The narrowing is published in `slot_kinds["aggregate"]`, since the
+    list itself is only a list of names.
+
+  **The accumulator was already the right shape to extend.** A count is now a set of distinct values
+  and an avg was already a running `{sum, count}`, so both are finished by one pass:
+  `convert_avg_in_data_map` became `finalize_data_map` and dispatches on the accumulator's *shape*
+  rather than a flag, which makes it idempotent -- converting an avg twice used to raise "'float'
+  object is not subscriptable". `_build_data_map` also stopped spelling out the same accumulators the
+  update path spells out, and feeds the first row through `update_data_map` like every other row.
+
+  **Validated against SQL, not just against itself.** Two new sqlite parity tests over `sales.csv`
+  pin the two counts to `COUNT(*)` and `COUNT(DISTINCT state)`, and they disagree on that data, so a
+  test agreeing with both would prove nothing. The three MF parity queries that used `count(quant)`
+  now say `count(distinct quant)`, which is what their ESQL side asks for. Covered by
+  `tests/execution/test_count.py` (27 tests) plus the grammar bindings.
+
+  **Verified the guards bite**, and two of them did not at first, which is the part worth recording.
+  Reverting the distinct count fails 9, un-reserving the bare word in SELECT fails 21, reading
+  `g1.count` as a column fails 7, and skipping a row that holds a blank fails 6. But **dropping a
+  bare form from `forms` passed**: the test that runs the forms is parametrized over the list, so
+  deleting an entry deletes its own test -- a shape worth watching for anywhere a published list
+  drives its own coverage. It is now bound to `BARE_AGGREGATE_FUNCTIONS`, which the parser reads, and
+  fails. **Idempotence passed too**, because nothing called the finalize pass twice; it has a unit
+  test now rather than a docstring claiming a property nothing exercised.
+
+  **Prose updated to match**, and the G2 guard fired on the way through, which is it working: the
+  aggregate-forms assertion failed the moment `GRAMMAR` grew `group.count` and `syntax.md` still said
+  "two forms". SELECT gained a **Counting** section with the table of four spellings, the reserved
+  word, the blank-cell rule and the `sum / count` note; HAVING says the bare form works there too;
+  ORDER BY's examples now sort by `-count` rather than by a borrowed `-position.count`. Every example
+  was run against the engine over `sales.csv`.
+
+  **Portfolio-side follow-up, required, and this is the migration H4 was filed with.** No new name in
+  `esql.__all__` and no new slot kind, so neither the export-diff guard nor `unhandledSlotKinds`
+  fires -- `grammar.json` simply carries four forms where it carried two. What does change is
+  *meaning*: all 13 curated examples borrow `position` for a row count and now answer the distinct
+  count instead. They still parse, so nothing fails loudly; `esql-smoke` compares against the SQL
+  equivalent and is what catches them. Land it with D1 as filed. The result table must also read
+  `forms` rather than looking for a dot, or a bare `count` column is filed as a dimension.
 
 ## 3. Engine-side prep for the ESQL demo
 

--- a/.claude/status.md
+++ b/.claude/status.md
@@ -515,15 +515,26 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   `public/docs/syntax.md` section + an ESQL demo example. Pairs with HAS: HAS
   *filters* one grain by another; this *measures* across grains. Design captured now; build parked
   until the datasets/rename plumbing lands.
-- [ ] **mypy clean pass.** 152 errors (157 before v1.15.0, 159 before v1.9.0, and recorded as 156 until v1.8.0; the count was
+- [ ] **mypy clean pass.** **68 errors** (153 before the accumulator types landed in v1.15.0, 157
+  before v1.15.0's feature work, 159 before v1.9.0, and recorded as 156 until v1.8.0; the count was
   stale at 143 before that because `make typecheck` called
   `uv run mypy`, whose console script does not spawn, so the target errored out before reaching
-  mypy; fixed in v1.5.0 to `uv run python -m mypy`, the form every other target uses). All from
-  the dynamic evaluator: union comparisons
-  (`[operator]`) and TypedDict key-narrowing (`[typeddict-item]`/`[index]`) mypy can't follow
-  through runtime `'group' in aggregate` checks. Options: type the cell/accumulator boundaries as
-  `Any` (honest — a `_data_map` slot holds int|float|date or an avg `{'sum','count'}` dict), or
-  model parsed conditions as dataclasses. Until then `typecheck` stays advisory.
+  mypy; fixed in v1.5.0 to `uv run python -m mypy`, the form every other target uses).
+
+  **The count was never a count of problems.** 153 errors came from 61 lines, because a comparison
+  between two union-typed operands reports every illegal *pairing*: four ordering lines in
+  `_evaluate_actual_vs_expected_value` produced 60 of them between them. Naming what the values
+  actually are (`CellValue` / `Accumulator` / `ProjectedValue`) and then leaving nine genuinely
+  un-narrowable lines as targeted `# type: ignore[...]` with the invariant written next to them took
+  it to 68 without a single behavior change. `--warn-unused-ignores` is clean, so no ignore is
+  suppressing nothing.
+
+  What is left is two clusters and a tail: **30 `[arg-type]`**, **17 `[typeddict-item]`** plus
+  `[index]`, mostly TypedDict key-narrowing mypy cannot follow through runtime `'group' in
+  aggregate` checks, and **6 `[misc]`** which include the dead `__eq__` methods (Stream L). The
+  remaining fix is to model parsed conditions as dataclasses rather than TypedDicts, which is a real
+  change to the parser's shapes and wants its own pass. Until then `typecheck` stays advisory: it is
+  not in `make check` and not in CI.
 - [x] **Push the release** — done 2026-07-28. PR #2 (`v1.0.1` through `v1.4.0`) and PR #3
   (`v1.5.0`) merged to `main`, all tagged and pushed (`lucash0pe/extendedsql`). `v1.1.2` is
   deliberately untagged: it was never a release, only a version an auto-checkpoint commit wrote to
@@ -1135,6 +1146,18 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   rather than a flag, which makes it idempotent -- converting an avg twice used to raise "'float'
   object is not subscriptable". `_build_data_map` also stopped spelling out the same accumulators the
   update path spells out, and feeds the first row through `update_data_map` like every other row.
+
+  **What the slot holds is now named, because this release is what made the old claim false.**
+  `_data_map` was annotated `dict[str, str | int | bool | date]`, and the distinct count added a
+  `set` to it that the union never admitted, alongside the avg's `dict` and an avg's `float` result
+  that it had never admitted either. The union was also wrong about `float` at all nine sites that
+  spelled it out: a float column is ordinary, and `SELECT cust, quant.sum` over one returns floats.
+  Fixed here rather than left for a follow-up, on the J5 precedent -- the annotation is this
+  release's own line, so no wheel ever carried it. It is now three named types with the distinction
+  the one union was blurring: `CellValue` (what the frame holds), `Accumulator` (what a slot holds
+  *mid-flight*, which is not always an answer) and `ProjectedValue` (what reaches the caller, `None`
+  included). See the mypy item above for what that did to the error count and why the count was
+  never a count of problems.
 
   **Validated against SQL, not just against itself.** Two new sqlite parity tests over `sales.csv`
   pin the two counts to `COUNT(*)` and `COUNT(DISTINCT state)`, and they disagree on that data, so a

--- a/.claude/status.md
+++ b/.claude/status.md
@@ -1060,7 +1060,7 @@ All fixed and covered by the now-meaningful integration suite (see §3).
 ## v1.15.0 — `count` counts rows, `column.count` counts distinct (2026-07-30)
 
 - [x] **H4, which closes Stream H.** `SELECT state, count` is the row count, and `state.count` is now
-  the number of distinct states. Bumped `1.14.0 -> 1.15.0`; the gate is green at **423 tests**
+  the number of distinct states. Bumped `1.14.0 -> 1.15.0`; the gate is green at **425 tests**
   (was 386).
 
   ```sh
@@ -1089,9 +1089,18 @@ All fixed and covered by the now-meaningful integration suite (see §3).
     `count.sum`, `WHERE count > 5`, `ORDER BY count`. Only the bare word in a grouping-attribute slot
     is spoken for, and only `count` -- a column named `sum` is still projectable, because the check
     that refuses `SELECT cust, sum` runs *after* the word fails to name a column.
-  - **`g1.count` beats a column named `g1`.** Same tiebreak, decided the other way round from a
-    coin-flip: the group is declared by the query itself a few words earlier, in OVER, which makes it
-    the more deliberate of the two readings.
+  - **A group cannot be named after a column**, which is the collision H4 created and the one place
+    a tiebreak was the wrong instrument. `g1.count` is a group's row count, and if `g1` were also a
+    column the same words would equally be that column's distinct count. The first cut preferred the
+    group, on the reasoning that OVER declares it a few words earlier; that left the query legal and
+    its *meaning* dependent on the frame handed in, which is the failure H4 exists to remove rather
+    than a smaller version of it to accept. `parse_over_clause` now rejects the name where the query
+    chooses it, next to the case-collision rule it already enforced, and `_parse_aggregate`'s
+    two-part branch is a lookup rather than a decision.
+
+    This does not extend to `count.count`, which was never ambiguous: the word to the left of a dot
+    in `column.function` is a column by position, whatever it is called. The bare slot is the only
+    place a word could be either thing, and that is where the reservation lives.
   - **`sum / count` is no longer `avg`, and that is not a bug to fix.** It is a SQL identity, not a
     law; with `count` defined as distinct it does not hold, and `avg` keeps its own definition over
     rows. Pinned by a test so nobody restores it by "fixing" avg.
@@ -1118,7 +1127,9 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   pin the two counts to `COUNT(*)` and `COUNT(DISTINCT state)`, and they disagree on that data, so a
   test agreeing with both would prove nothing. The three MF parity queries that used `count(quant)`
   now say `count(distinct quant)`, which is what their ESQL side asks for. Covered by
-  `tests/execution/test_count.py` (27 tests) plus the grammar bindings.
+  `tests/execution/test_count.py` (28 tests) plus the grammar bindings, and the group-name rule by
+  one test either side of the seam: `parse_over_clause` directly and the accessor for the query that
+  motivates it.
 
   **Verified the guards bite**, and two of them did not at first, which is the part worth recording.
   Reverting the distinct count fails 9, un-reserving the bare word in SELECT fails 21, reading

--- a/.claude/status.md
+++ b/.claude/status.md
@@ -204,9 +204,13 @@ clause gaining a rule upstream simply goes unreflected downstream.
   `HAVING_OPERATORS` claim CONTAINS fails the test rather than reaching the demo. That kills the
   silent-drift failure mode, which was the point, without pretending the description is generated.
 
-- [ ] **G2. A guard for the prose.** The clause reference cards are hand-written and only the keyword
+- [x] **G2. A guard for the prose.** The clause reference cards are hand-written and only the keyword
   list is asserted today. G1 gives the cards something to be checked against: they can now be
   generated from `GRAMMAR` or asserted to agree with it.
+
+  **Shipped in v1.14.0**, asserted rather than generated. See that entry in the settled record. With
+  it, Stream G closes: `slot_kinds`/`accepts`, the operator dtype axis and the prose that restates
+  them are all bound to the parser.
 
 ---
 
@@ -1005,6 +1009,46 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   new slot kind and `ORDER BY`'s `accepts` grew, which is exactly the channel Stream G built for this.
   Its caret menu can now offer something in ORDER BY for the first time: the SELECT terms of the query
   in hand, which is a list it already has. `ORDER BY`'s `separator` also changed from `null` to `","`.
+
+## v1.14.0 — the prose is bound to the grammar (2026-07-30)
+
+- [x] **G2, which closes Stream G.** `tests/test_syntax_docs.py` asserts `public/docs/syntax.md`
+  against `GRAMMAR` and the parser's token sets. Bumped `1.13.0 -> 1.14.0`; the gate is green at
+  **386 tests** (was 376).
+
+  **Asserted, not generated.** Generating the doc from `GRAMMAR` was the other option G2 named and
+  would have meant a build step for a document whose value is the half no export can hold: what a
+  clause is *for*, why `HAS` is not a comparison, what an entry value is doing. So the doc stays
+  hand-written and prose stays unchecked; only the parts that *restate a rule* are bound.
+
+  **A claim is marked as one.** `<!-- grammar:operators WHERE also:==,HAS -->` in front of a
+  paragraph says the operators named there are WHERE's operators, and `also:` names the ones written
+  elsewhere in the section. Six markers: keywords, aggregate functions, the three clause operator
+  lists, the operator-dtype table, and the text delimiters. Unmarked prose is not checked, because a
+  regex over English produces false positives and a gate that cries wolf gets bypassed.
+
+  **The loose version of this test does not work, and writing it proved that.** The first cut asked
+  "does every legal operator appear somewhere in the clause's section", both directions covered by
+  one cheap check. Tampering found it passes when HAVING gains the `HAS` operator, because HAVING's
+  section *does* mention `HAS` -- in a sentence saying it is rejected. A mention that says the
+  opposite still counts as a mention. That is why the marker carries the whole claim now: the list
+  plus its `also:` set must equal the clause's operators exactly, and each `also:` name still has to
+  be found in the section. Worth recording because the loose check is the one that looks sufficient.
+
+  **What the doc got to say for itself.** Two places disagreed with the parser only in vocabulary,
+  not in substance: the doc writes "text" where the engine's dtype family is "string". That is a
+  rename declared in one dict in the test rather than a change to either side, since "text column"
+  is the right words for a reader and `string` is the right key for a host.
+
+  Verified the guards bite, seven ways: documenting CONTAINS in HAVING, HAVING gaining an operator
+  nobody documents, WHERE losing one the doc still promises, an `also:` name written nowhere, a
+  wrong cell in the dtype table, a deleted marker, and a new aggregate function shipping
+  undocumented. Each fails, and the deleted-marker case is the one that matters most: a claim cannot
+  go unguarded by quietly removing its marker.
+
+  **Portfolio-side follow-up: none.** No export changed and no new name. Worth knowing that the
+  reference cards portfolio renders are its own copy of this material, and this guard covers only
+  the doc in this repo. The same marker idea is available there if its cards are ever worth binding.
 
 ## 3. Engine-side prep for the ESQL demo
 

--- a/.claude/status.md
+++ b/.claude/status.md
@@ -1060,7 +1060,7 @@ All fixed and covered by the now-meaningful integration suite (see §3).
 ## v1.15.0 — `count` counts rows, `column.count` counts distinct (2026-07-30)
 
 - [x] **H4, which closes Stream H.** `SELECT state, count` is the row count, and `state.count` is now
-  the number of distinct states. Bumped `1.14.0 -> 1.15.0`; the gate is green at **425 tests**
+  the number of distinct states. Bumped `1.14.0 -> 1.15.0`; the gate is green at **428 tests**
   (was 386).
 
   ```sh
@@ -1083,12 +1083,25 @@ All fixed and covered by the now-meaningful integration suite (see §3).
 
   Decisions worth keeping:
 
-  - **`count` is reserved in SELECT, above a column of the same name.** The alternative was to let
-    the frame decide, and then the same query means different things over different data. A column
-    called `count` stays reachable everywhere it cannot be confused with the function: `count.count`,
-    `count.sum`, `WHERE count > 5`, `ORDER BY count`. Only the bare word in a grouping-attribute slot
-    is spoken for, and only `count` -- a column named `sum` is still projectable, because the check
-    that refuses `SELECT cust, sum` runs *after* the word fails to name a column.
+  - **`count` is a reserved name and a frame using it for a column is refused.** Three positions
+    were tried and the first two were wrong. *Prefer the aggregate* leaves `SELECT venue, count`
+    legal and meaning different things over different data. *Prefer the column* puts the row count
+    out of reach for that frame alone. Both are invisible to whoever writes the query, and the thing
+    that is visible -- the column's name -- is the thing that can be changed, so
+    `accessor._reject_reserved_columns` refuses the frame, names the column and asks for a rename.
+    Same instrument as the group-name rule below and the same reasoning: refuse the collision where
+    the name is chosen rather than resolve it at every reference.
+
+    **Only names that can be a whole aggregate are taken**, which is `BARE_AGGREGATE_FUNCTIONS` and
+    today means `count` alone. `sum` is never an aggregate by itself, so a column may be called
+    `sum`, `SELECT cust, sum` projects it and `sum.sum` is its total. Reserving all five would have
+    cost four names to protect against an ambiguity only one of them has.
+
+    **It gets its own `ParsingErrorType.RESERVED_COLUMN`**, and it is raised when the accessor is
+    handed the frame rather than when a query is parsed, so it names a *column* rather than a query
+    token. Same shape as `STRING_LITERAL` in v1.8.0: a new enum value, so a host switching on
+    `error_type` sees a new case. Worth knowing that `df.esql` itself now raises for such a frame,
+    before any query exists.
   - **A group cannot be named after a column**, which is the collision H4 created and the one place
     a tiebreak was the wrong instrument. `g1.count` is a group's row count, and if `g1` were also a
     column the same words would equally be that column's distinct count. The first cut preferred the
@@ -1098,9 +1111,9 @@ All fixed and covered by the now-meaningful integration suite (see §3).
     chooses it, next to the case-collision rule it already enforced, and `_parse_aggregate`'s
     two-part branch is a lookup rather than a decision.
 
-    This does not extend to `count.count`, which was never ambiguous: the word to the left of a dot
-    in `column.function` is a column by position, whatever it is called. The bare slot is the only
-    place a word could be either thing, and that is where the reservation lives.
+    Both rules landed on the same answer from opposite directions, which is worth noting: a name
+    the language reads two ways is refused where it is written down, in the OVER clause for a group
+    and in the data for a column.
   - **`sum / count` is no longer `avg`, and that is not a bug to fix.** It is a SQL identity, not a
     law; with `count` defined as distinct it does not hold, and `avg` keeps its own definition over
     rows. Pinned by a test so nobody restores it by "fixing" avg.
@@ -1127,9 +1140,9 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   pin the two counts to `COUNT(*)` and `COUNT(DISTINCT state)`, and they disagree on that data, so a
   test agreeing with both would prove nothing. The three MF parity queries that used `count(quant)`
   now say `count(distinct quant)`, which is what their ESQL side asks for. Covered by
-  `tests/execution/test_count.py` (28 tests) plus the grammar bindings, and the group-name rule by
-  one test either side of the seam: `parse_over_clause` directly and the accessor for the query that
-  motivates it.
+  `tests/execution/test_count.py` (30 tests) plus the grammar bindings, and the two collision rules
+  by one test either side of each seam: `parse_over_clause` directly and the accessor for the query
+  that motivates it, the reserved column at `df.esql` and through `query` and `validate`.
 
   **Verified the guards bite**, and two of them did not at first, which is the part worth recording.
   Reverting the distinct count fails 9, un-reserving the bare word in SELECT fails 21, reading
@@ -1151,7 +1164,8 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   `esql.__all__` and no new slot kind, so neither the export-diff guard nor `unhandledSlotKinds`
   fires -- `grammar.json` simply carries four forms where it carried two. What does change is
   *meaning*: all 13 curated examples borrow `position` for a row count and now answer the distinct
-  count instead. They still parse, so nothing fails loudly; `esql-smoke` compares against the SQL
+  count instead. `RESERVED_COLUMN` is a new `error_type` its funnel should have a case for, and any
+  dataset with a `count` column now fails its build with that message rather than at query time. They still parse, so nothing fails loudly; `esql-smoke` compares against the SQL
   equivalent and is what catches them. Land it with D1 as filed. The result table must also read
   `forms` rather than looking for a dot, or a bare `count` column is filed as a dimension.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ query's, so the column names you get back do not depend on how the query was typ
 the exception and stays case sensitive, because its contents are data: see
 [Case](public/docs/syntax.md#case).
 
+One name is reserved in your data: a column called `count` (in any case) is refused, with a
+`ParsingError` asking you to rename it. `count` on its own is a query's way of saying "how many
+rows", so a column of that name would be a word with two readings and no way to pick between them.
+Every other aggregate function needs a column before it, so a column named `sum` or `avg` is fine.
+
 Aggregates are rounded to 2 decimal places by default. You can change this by passing a different value to the query as `decimal_places`.
 
 ```python

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -117,6 +117,8 @@ A blank cell is not a value, so it is skipped by a distinct count and by every o
 
 The OVER clause determines the names of the groups that are used to compute aggregates within the conditions set in the [SUCH THAT](#such-that) clause. The groups names are separated by commans. Group names can only include letters, numbers, and `_`, and they are not case sensitive: `OVER G1` can be referenced as `g1` anywhere below. Because they are not case sensitive, two names differing only in case would name the same group and are rejected. It is recommended that group names are short and concise.
 
+A group also cannot be named after a column of the queried data, and that is rejected too. The word to the left of a dot is read as a group or as a column depending on which one it names, so a name that is both makes `sales.count` mean either the group's row count or the distinct count of a column called `sales`. Choosing between those readings would make the same query mean different things over different data, so the name is refused where you pick it instead.
+
 If you want to define two groups with the names `g1` and `g2`, like in the SELECT clause example above, you would write:
 
 `OVER g1, g2`

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -110,7 +110,9 @@ The other four functions are unchanged and always run over rows, not over distin
 
 A blank cell is not a value, so it is skipped by a distinct count and by every other function, while a row count still counts its row. On a column that is blank everywhere, a distinct count has no value at all rather than zero, the same as any aggregate with nothing to compute.
 
-`count` is a reserved word where a grouping attribute would go: written on its own in [SELECT](#select) it is the row count even if the queried data has a column of that name, since the same query has to mean the same thing over every frame. Such a column is still reachable everywhere else, `count.count` and `WHERE count > 5` included.
+`count` is a reserved name, and the queried data cannot use it for a column. Written on its own the word is the row count wherever a column could go, so a column of that name would be a word with two readings and nothing in the query to pick between them. ESQL refuses such a table outright, names the column and asks you to rename it in the data, rather than preferring a reading and answering.
+
+Only names that can be a whole aggregate are taken this way, which today is `count` alone. `sum` is never an aggregate by itself, so a column may be called `sum` and `sum.sum` is its total.
 
 
 ## OVER

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -38,7 +38,8 @@ HAVING [aggregate conditions]
 ORDER BY [variable order]
 ```
 
-The query language has 6 keywords: SELECT, OVER, WHERE, SUCH THAT, HAVING, and ORDER BY. The follpowing sections explore the the syntax and use cases of each keyword. ESQL queries do not contain a FROM clause like in SQL since a datatable must be passed in through the DataFrame accessor or through the API. Queries do not require all of the keywords, but variable projection (in the [SELECT](#select) clause) must be performed for the query to produce an output.
+<!-- grammar:keywords -->
+The query language has 6 keywords: `SELECT`, `OVER`, `WHERE`, `SUCH THAT`, `HAVING`, and `ORDER BY`. The follpowing sections explore the the syntax and use cases of each keyword. ESQL queries do not contain a FROM clause like in SQL since a datatable must be passed in through the DataFrame accessor or through the API. Queries do not require all of the keywords, but variable projection (in the [SELECT](#select) clause) must be performed for the query to produce an output.
 
 ### Case
 
@@ -51,6 +52,7 @@ A result is labelled with the *canonical* spelling rather than the query's, so t
 
 ### Text values
 
+<!-- grammar:text-delimiters -->
 A text value is written between a matched pair of `'` or `"`. Either delimiter holds the other as ordinary text, so a value containing an apostrophe is usually easiest to write in double quotes:
 
 ```sh
@@ -83,6 +85,7 @@ The SELECT clause determines the output columns of the query. It contains two ty
 
 Grouping attrubutes are the column names of the datatable that is being queried. It is important to know that ESQL will automatically group these variables (like GROUP BY in SQL), so all rows that contain the same combination of values in the grouping attributes will be in the same row in the output.
 
+<!-- grammar:aggregate-functions -->
 Aggregates are what will be calculated for each combination of grouping attributes. Aggregates must always contain an aggregate function supported by ESQL (`sum`, `avg`, `min`, `max`, `count`) and a column that contains numerical data (e.g. `quant` from the `sales` table) unless the aggregate function is `count`, which works with columns that contain any datatype.  Aggregates can be apart of a group defined in the [OVER](#over) clause. ESQL syntax exclusively utilizes dot notation with groups first, then the column name, and the aggregate function last. Therefore, aggregates can come in two forms: `column.function` or `group.column.function`.
 
 If you wanted to write a query with the grouping attributes `cust` and `prod` that computes the maximum value of `quant`, the sum of `quant` for the group `g1`, and the average of `quant` for the group `g2`, you would write:
@@ -107,11 +110,14 @@ The following would also be a valid OVER clause:
 
 The WHERE clause determines which rows will be filtered out of the inputted datatable before computing any aggregates. The resulting table will be used to compute any global aggregates.
 
+<!-- grammar:operators WHERE also:==,HAS -->
 WHERE clause conditions can include any column in the inputted datatable followed by a conditional operator (`>`, `<`, `=`, `>=`, `<=`, `!=`, `CONTAINS`) and the value that you want to compare to. The comparison value should be the same datatype as the column you are referencing. 
 
 ### Which operators apply to which columns
 
 Not every operator applies to every column. Equality works on all four kinds of column, ordering needs values with an order, and `CONTAINS` needs text:
+
+<!-- grammar:operator-dtypes -->
 
 | column | `=` `!=` | `>` `>=` `<` `<=` | `CONTAINS` |
 |---|---|---|---|
@@ -189,6 +195,7 @@ Four rules to know:
 ## SUCH THAT
 The SUCH THAT clause determines which of the remaining rows will be used to compute aggregates within a group. The SUCH THAT clause should contain a section for each defined group in the [OVER](#over) clause. These sections must be divided by commas, must contain only one group, and must not contain a group that is already defined in another section of the SUCH THAT clause.
 
+<!-- grammar:operators SUCH THAT also:== -->
 SUCH THAT clause conditions can include any column in the inputted datatable but every column name must start with the group name of the section combined using dot notation (e.g. `group1.month`). The group and column is followed by a conditional operator (`>`, `<`, `=`, `>=`, `<=`, `!=`, `CONTAINS`) and the value that you want to compare to. The comparison value should be the same datatype as the column you are referencing. [Which operators apply to which columns](#which-operators-apply-to-which-columns) governs here exactly as it does in WHERE.
 
 Conditions can be combined with `AND` and `OR`. The `NOT` operator can also be used for negation. 
@@ -253,7 +260,10 @@ The HAVING clause determines which of the grouped rows will be included in the o
 
 Like in the [SELECT](#select) clause, aggregates can come in the form `column.function` or `group.column.function`. The HAVING clause is not limited to the aggregates defined in the SELECT clause. The only limitation is that they must be contain an aggregate function (`sum`, `avg`, `min`, `max`, `count`) and a column that contains numerical data (e.g. `quant` from the `sales` table) unless the aggregate function used is `count`. They can also contain a group defined in the `OVER` clause.
 
-HAVING clause conditions must include an aggregate followed by a conditional operator (`>`, `<`, `=`, `>=`, `<=`, `!=`) and the value that you want to compare to. The comparison value must be numeric, as all aggregates are computed numeric values. For that reason [`CONTAINS`](#contains) is the one conditional operator HAVING does not accept, and [`HAS`](#has) is rejected too, since it filters rows rather than groups. 
+<!-- grammar:operators HAVING also:== -->
+HAVING clause conditions must include an aggregate followed by a conditional operator (`>`, `<`, `=`, `>=`, `<=`, `!=`) and the value that you want to compare to.
+
+The comparison value must be numeric, as all aggregates are computed numeric values. For that reason [`CONTAINS`](#contains) is the one conditional operator HAVING does not accept, and [`HAS`](#has) is rejected too, since it filters rows rather than groups. 
 
 Conditions can be combined with `AND` and `OR`. The `NOT` operator can be used for negation. 
 

--- a/public/docs/syntax.md
+++ b/public/docs/syntax.md
@@ -11,6 +11,7 @@ The per-clause rules this document explains in prose are also available machine-
 - [Structure](#structure)
   - [Text values](#text-values)
 - [SELECT](#select)
+  - [Counting](#counting)
 - [OVER](#over)
 - [WHERE](#where)
   - [Which operators apply to which columns](#which-operators-apply-to-which-columns)
@@ -86,11 +87,30 @@ The SELECT clause determines the output columns of the query. It contains two ty
 Grouping attrubutes are the column names of the datatable that is being queried. It is important to know that ESQL will automatically group these variables (like GROUP BY in SQL), so all rows that contain the same combination of values in the grouping attributes will be in the same row in the output.
 
 <!-- grammar:aggregate-functions -->
-Aggregates are what will be calculated for each combination of grouping attributes. Aggregates must always contain an aggregate function supported by ESQL (`sum`, `avg`, `min`, `max`, `count`) and a column that contains numerical data (e.g. `quant` from the `sales` table) unless the aggregate function is `count`, which works with columns that contain any datatype.  Aggregates can be apart of a group defined in the [OVER](#over) clause. ESQL syntax exclusively utilizes dot notation with groups first, then the column name, and the aggregate function last. Therefore, aggregates can come in two forms: `column.function` or `group.column.function`.
+Aggregates are what will be calculated for each combination of grouping attributes. An aggregate names one of the aggregate functions supported by ESQL (`sum`, `avg`, `min`, `max`, `count`) and, for every function but `count`, a column that contains numerical data (e.g. `quant` from the `sales` table). `count` is the exception at both ends: it works with a column of any datatype, and it is the one function that can be written with no column at all. Aggregates can be apart of a group defined in the [OVER](#over) clause. ESQL syntax exclusively utilizes dot notation with groups first, then the column name, and the aggregate function last. Therefore, aggregates come in four forms: `count`, `group.count`, `column.function` or `group.column.function`.
 
 If you wanted to write a query with the grouping attributes `cust` and `prod` that computes the maximum value of `quant`, the sum of `quant` for the group `g1`, and the average of `quant` for the group `g2`, you would write:
 
 `SELECT cust, prod, quant.max, g1.quant.sum, g2.quant.avg`
+
+### Counting
+
+`count` answers two different questions, and which one it answers is decided by whether it names a column:
+
+| written | answers |
+|---|---|
+| `count` | how many rows this group holds |
+| `prod.count` | how many distinct products this group holds |
+| `g1.count` | how many rows group `g1` holds |
+| `g1.prod.count` | how many distinct products group `g1` holds |
+
+A row count names no column because no column bears on it. That is the whole reason the bare form exists: with only `column.count` to write, `SELECT cust, prod.count` had to borrow a column to count rows, and under a clause that groups automatically it reads as "the products, counted" while answering something else. Now the two questions have two spellings, and a column written in an aggregate always bears on the number that comes back.
+
+The other four functions are unchanged and always run over rows, not over distinct values. So `quant.sum` divided by `quant.count` is *not* `quant.avg`, the way it is in SQL: `avg` keeps its own definition, and the identity simply does not hold once `count` means something else.
+
+A blank cell is not a value, so it is skipped by a distinct count and by every other function, while a row count still counts its row. On a column that is blank everywhere, a distinct count has no value at all rather than zero, the same as any aggregate with nothing to compute.
+
+`count` is a reserved word where a grouping attribute would go: written on its own in [SELECT](#select) it is the row count even if the queried data has a column of that name, since the same query has to mean the same thing over every frame. Such a column is still reachable everywhere else, `count.count` and `WHERE count > 5` included.
 
 
 ## OVER
@@ -258,7 +278,7 @@ Quoting turns a reference back into text. `g1.prod = 'cust'` looks for the liter
 
 The HAVING clause determines which of the grouped rows will be included in the output based on aggregate values.
 
-Like in the [SELECT](#select) clause, aggregates can come in the form `column.function` or `group.column.function`. The HAVING clause is not limited to the aggregates defined in the SELECT clause. The only limitation is that they must be contain an aggregate function (`sum`, `avg`, `min`, `max`, `count`) and a column that contains numerical data (e.g. `quant` from the `sales` table) unless the aggregate function used is `count`. They can also contain a group defined in the `OVER` clause.
+Aggregates take the same four forms here as in the [SELECT](#select) clause, `count` and `g1.count` included, so `HAVING count > 100` keeps the groups with more than a hundred rows. The HAVING clause is not limited to the aggregates defined in the SELECT clause. The only limitation is that they must be contain an aggregate function (`sum`, `avg`, `min`, `max`, `count`) and a column that contains numerical data (e.g. `quant` from the `sales` table) unless the aggregate function used is `count`. They can also contain a group defined in the `OVER` clause.
 
 <!-- grammar:operators HAVING also:== -->
 HAVING clause conditions must include an aggregate followed by a conditional operator (`>`, `<`, `=`, `>=`, `<=`, `!=`) and the value that you want to compare to.
@@ -282,12 +302,12 @@ The following is also a valid HAVING clause, assuming the groups `g1` and `g2` a
 The ORDER BY clause determines the order of the rows in the outputted table. It takes a comma-separated list of [SELECT](#select) terms to sort by, outermost first. A term is a grouping attribute or an aggregate, and a `-` in front of it sorts that term descending:
 
 ```sh
-ORDER BY song                    -- alphabetically by song
-ORDER BY -position.count         -- most played first
-ORDER BY -position.count, song   -- most played first, ties broken alphabetically
+ORDER BY song           -- alphabetically by song
+ORDER BY -count         -- most played first
+ORDER BY -count, song   -- most played first, ties broken alphabetically
 ```
 
-Each term carries its own direction, so `ORDER BY -position.count, song` runs the count down and the song up.
+Each term carries its own direction, so `ORDER BY -count, song` runs the count down and the song up.
 
 A term must be something the query returns. This is stricter than SQL, where ORDER BY can name a column the query does not select, and grouping is why: a column that is neither a grouping attribute nor inside an aggregate has no single value in an output row to sort by. Naming one is a parsing error that lists the terms available.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.13.0"
+version = "1.14.0"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.14.0"
+version = "1.15.0"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/esql/accessor.py
+++ b/src/esql/accessor.py
@@ -6,7 +6,9 @@ from beartype.vale import Is
 from pandas.api.extensions import register_dataframe_accessor
 
 from esql.execution.execute import execute
+from esql.parser.error import ParsingError, ParsingErrorType
 from esql.parser.parse import get_parsed_query
+from esql.parser.util import BARE_AGGREGATE_FUNCTIONS
 
 IntGreaterThanZero = Annotated[int, Is[lambda x: x > 0]]
 
@@ -14,6 +16,7 @@ IntGreaterThanZero = Annotated[int, Is[lambda x: x > 0]]
 @register_dataframe_accessor("esql")
 class ESQLAccessor:
     def __init__(self, data: pd.DataFrame):
+        _reject_reserved_columns(data)
         self.data = _enforce_allowed_dtypes(data)
 
     @beartype
@@ -36,6 +39,30 @@ class ESQLAccessor:
         still return zero rows.
         """
         get_parsed_query(self.data, query)
+
+
+def _reject_reserved_columns(data: pd.DataFrame) -> None:
+    """Refuse a frame whose columns use a name the language has taken.
+
+    Only the names that can be written as a whole aggregate are taken: `count` means the row count
+    wherever a grouping attribute could go, so a column of that name is a word with two readings.
+    Every other function needs a column before it (`sum` is never an aggregate on its own), so a
+    column may be called `sum` and this rule leaves it alone.
+
+    Refused here, at the frame, rather than resolved per reference. Preferring one reading would
+    leave `SELECT venue, count` legal and its meaning decided by the data handed in, and preferring
+    the other would put the row count out of reach for that frame alone. Neither is something a
+    query writer can see. Renaming the column is, so the error asks for that and names it.
+    """
+    reserved = {name.lower() for name in BARE_AGGREGATE_FUNCTIONS}
+    for column in data.columns:
+        if str(column).lower() in reserved:
+            raise ParsingError(
+                ParsingErrorType.RESERVED_COLUMN,
+                f"Column '{column}' is named after the aggregate '{str(column).lower()}', which ESQL "
+                f"reads as the row count wherever a column could go. Rename the column in the data.",
+                token=str(column),
+            )
 
 
 def _enforce_allowed_dtypes(data: pd.DataFrame) -> pd.DataFrame:

--- a/src/esql/execution/algorithms.py
+++ b/src/esql/execution/algorithms.py
@@ -3,7 +3,7 @@ from datetime import date
 import pandas as pd
 
 from esql.execution.error import RuntimeError
-from esql.execution.grouped_row import GroupedRow
+from esql.execution.grouped_row import Accumulator, CellValue, GroupedRow, ProjectedValue
 from esql.parser.types import (
     AggregatesDict,
     LogicalOperator,
@@ -172,7 +172,7 @@ def _has_entry_value(condition: dict) -> bool:
     return False
 
 
-def _bind_entry_values(condition: dict, entry_values: dict[str, str | int | bool | date]) -> dict:
+def _bind_entry_values(condition: dict, entry_values: dict[str, CellValue]) -> dict:
     """Replace every entry value with the literal the grouped row being computed holds for it.
 
     The same shape as `_resolve_semi_joins`: a condition that is not a question about the row in
@@ -311,7 +311,7 @@ def _evaluate_condition(condition: dict, row: list, column_indices: dict[str, in
         raise RuntimeError(f"Unknown logical operator: {operator}")
 
 
-def _evaluate_having_clause(condition: ParsedHavingClause, data_map: dict[str, str | int | bool | date]) -> bool:
+def _evaluate_having_clause(condition: ParsedHavingClause, data_map: dict[str, Accumulator]) -> bool:
     operator = condition.get("operator")
     if operator == LogicalOperator.NOT:
         return not _evaluate_having_clause(condition=condition.get("condition"), data_map=data_map)
@@ -342,7 +342,7 @@ def _evaluate_having_clause(condition: ParsedHavingClause, data_map: dict[str, s
 
 
 def _evaluate_actual_vs_expected_value(
-    actual_value: str | int | bool | date | None, operator: str, condition_value: str | int | bool | date
+    actual_value: CellValue | None, operator: str, condition_value: CellValue
 ) -> bool:
     # SQL NULL semantics: a comparison with a missing operand is not true, so the row drops from
     # the result instead of raising. Two sources of a missing operand: a blank cell in the data
@@ -357,14 +357,21 @@ def _evaluate_actual_vs_expected_value(
         return False
     if operator in ["=", "=="]:
         return actual_value == condition_value
+    # The four ordering comparisons are deliberately un-narrowed, and the ignores are the sharp edge
+    # left sharp rather than papered over with `Any`, which would also silence a real error here.
+    # Both operands are the same dtype family by the time they arrive: the parser reads a comparison
+    # value as its column's own kind (v1.12.0), and ordering on a string or bool column is refused
+    # outright before execution (v1.11.0, and it is the published `GRAMMAR["operators"]["dtypes"]`
+    # table). mypy sees neither guarantee, so it cross-products the union and reports every pairing
+    # the parser has already ruled out. Narrowing here would restate that table in a third place.
     elif operator == ">":
-        return actual_value > condition_value
+        return actual_value > condition_value  # type: ignore[operator]
     elif operator == "<":
-        return actual_value < condition_value
+        return actual_value < condition_value  # type: ignore[operator]
     elif operator == ">=":
-        return actual_value >= condition_value
+        return actual_value >= condition_value  # type: ignore[operator]
     elif operator == "<=":
-        return actual_value <= condition_value
+        return actual_value <= condition_value  # type: ignore[operator]
     elif operator == "!=":
         return actual_value != condition_value
     elif operator == "CONTAINS":
@@ -381,7 +388,7 @@ def _evaluate_actual_vs_expected_value(
 ###############################################################################
 def project_select_attributes(
     parsed_select_clause: ParsedSelectClause, grouped_table: list[GroupedRow], decimal_places: int
-) -> list[dict[str, str | int | bool | date]]:
+) -> list[dict[str, ProjectedValue]]:
     select_items = parsed_select_clause["select_items_in_order"]
     projected_table = []
     for grouped_row in grouped_table:
@@ -404,8 +411,8 @@ def _sort_key(value):
 
 
 def order_by_sort(
-    projected_table: list[dict[str, str | int | bool | date]], order_by: list[SortTerm]
-) -> list[dict[str, str | int | bool | date]]:
+    projected_table: list[dict[str, ProjectedValue]], order_by: list[SortTerm]
+) -> list[dict[str, ProjectedValue]]:
     """Sort the projected rows by each term, outermost first.
 
     One pass per term, applied from the innermost key outwards, which is the standard way to get a

--- a/src/esql/execution/algorithms.py
+++ b/src/esql/execution/algorithms.py
@@ -93,7 +93,7 @@ def build_grouped_table(
 
     grouped_table = list(grouped_rows.values())
     for grouped_row in grouped_table:
-        grouped_row.convert_avg_in_data_map()
+        grouped_row.finalize_data_map()
 
     if parsed_having_clause:
         grouped_table = [

--- a/src/esql/execution/grouped_row.py
+++ b/src/esql/execution/grouped_row.py
@@ -1,8 +1,30 @@
 from datetime import date
+from typing import Any
 
 import pandas as pd
 
 from esql.parser.types import AggregatesDict, GlobalAggregate, GroupAggregate, aggregate_key
+
+CellValue = str | int | float | bool | date
+"""A value as the frame holds it: what a row cell contains, and what a grouping attribute is.
+
+`float` is in here because a float column is ordinary -- a duration in seconds, a price -- and it
+is also what an avg finishes as.
+"""
+
+Accumulator = CellValue | set[CellValue] | dict[str, Any]
+"""What a `_data_map` slot holds, which is not always an answer.
+
+Two of the functions accumulate a shape rather than a running value, and `finalize_data_map` is
+what turns each into the number the query asked for: a **column count** accumulates the *set* of
+distinct values and finishes as its size, an **avg** accumulates a running `{"sum", "count"}` and
+finishes as the quotient. So a slot is a plain `CellValue` only before those two have touched it,
+or after that pass has run.
+"""
+
+ProjectedValue = CellValue | None
+"""A finished value on its way to the caller. `None` when a select item names something the
+grouped row holds no value for, which comes back as a blank cell rather than raising."""
 
 
 class GroupedRow:
@@ -15,14 +37,14 @@ class GroupedRow:
         self,
         grouping_attributes: list[str],
         aggregates: AggregatesDict,
-        initial_row: list[str | int | bool | date],
+        initial_row: list[CellValue],
         column_indices: dict[str, int],
     ):
         self.grouping_attributes = grouping_attributes
         self.aggregates = aggregates
         self._initial_row = initial_row
         self._column_indices = column_indices
-        self._data_map: dict[str, str | int | bool | date] = {}
+        self._data_map: dict[str, Accumulator] = {}
         self._build_data_map()
 
     def _build_data_map(self) -> None:
@@ -38,7 +60,7 @@ class GroupedRow:
         for aggregate in self.aggregates["global_scope"]:
             self.update_data_map(aggregate=aggregate, row=self._initial_row)
 
-    def update_data_map(self, aggregate: GlobalAggregate | GroupAggregate, row: list[str | int | bool | date]) -> None:
+    def update_data_map(self, aggregate: GlobalAggregate | GroupAggregate, row: list[CellValue]) -> None:
         """Fold one row into one aggregate's running value.
 
         `count` accumulates rather than adds up, in two different ways. The **row count** (`count`,
@@ -46,12 +68,18 @@ class GroupedRow:
         A **column count** (`quant.count`) counts the column's *distinct* values, so it accumulates
         the set of them and `finalize_data_map` takes its size; a missing value is not a value, and
         is skipped like it is for every other function.
+
+        The ignores below are one sharp edge left sharp. Each branch knows the slot's shape because
+        `function` is what put it there -- a `sum` slot holds what a previous `sum` wrote, an `avg`
+        slot the running `{"sum", "count"}` -- but that ties a *value* to a *type*, which mypy
+        cannot follow, so it offers every member of `Accumulator` instead. Typing the slot `Any`
+        would silence these and every real error here with them.
         """
         function = aggregate["function"]
         key = aggregate_key(aggregate)
 
         if aggregate["column"] is None:
-            self._data_map[key] = self._data_map.get(key, 0) + 1
+            self._data_map[key] = self._data_map.get(key, 0) + 1  # type: ignore[operator]
             return
 
         value = row[self._column_indices[aggregate["column"]]]
@@ -59,23 +87,23 @@ class GroupedRow:
             return
 
         if function == "count":
-            self._data_map.setdefault(key, set()).add(value)
+            self._data_map.setdefault(key, set()).add(value)  # type: ignore[union-attr]
         elif key not in self._data_map:
             if function in ["sum", "min", "max"]:
                 self._data_map[key] = value
             elif function == "avg":
                 self._data_map[key] = {"sum": value, "count": 1}
         elif function == "sum":
-            self._data_map[key] += value
+            self._data_map[key] += value  # type: ignore[operator]
         elif function == "min":
-            if value < self._data_map[key]:
+            if value < self._data_map[key]:  # type: ignore[operator]
                 self._data_map[key] = value
         elif function == "max":
-            if value > self._data_map[key]:
+            if value > self._data_map[key]:  # type: ignore[operator]
                 self._data_map[key] = value
         elif function == "avg":
             values = self._data_map[key]
-            self._data_map[key] = {"sum": values["sum"] + value, "count": values["count"] + 1}
+            self._data_map[key] = {"sum": values["sum"] + value, "count": values["count"] + 1}  # type: ignore[index]
 
     # This must be called on all GroupedRows after they have been filtered by the WHERE and SUCH THAT clauses
     def finalize_data_map(self) -> None:
@@ -94,7 +122,7 @@ class GroupedRow:
                 self._data_map[key] = value["sum"] / value["count"]
 
     @property
-    def data_map(self):
+    def data_map(self) -> dict[str, Accumulator]:
         return self._data_map
 
     def __str__(self):

--- a/src/esql/execution/grouped_row.py
+++ b/src/esql/execution/grouped_row.py
@@ -22,70 +22,76 @@ class GroupedRow:
         self.aggregates = aggregates
         self._initial_row = initial_row
         self._column_indices = column_indices
-        self._data_map = self._build_data_map()
+        self._data_map: dict[str, str | int | bool | date] = {}
+        self._build_data_map()
 
-    def _build_data_map(self) -> dict[str, str | int | bool | date]:
-        data_map = {}
+    def _build_data_map(self) -> None:
+        """The grouping attribute values, plus the first row's contribution to each aggregate.
+
+        The first row is fed through `update_data_map` like every other one rather than being
+        initialized separately here: the two used to spell out the same accumulators side by side,
+        which is one rule in two places.
+        """
         for attribute in self.grouping_attributes:
             index = self._column_indices[attribute]
-            data_map[attribute] = self._initial_row[index]
+            self._data_map[attribute] = self._initial_row[index]
         for aggregate in self.aggregates["global_scope"]:
-            column = aggregate["column"]
-            function = aggregate["function"]
-            index = self._column_indices[column]
-            value = self._initial_row[index]
-            if pd.isna(value):
-                continue
-            key = aggregate_key(aggregate)
-            if function in ["sum", "min", "max"]:
-                data_map[key] = value
-            elif function == "count":
-                data_map[key] = 1
-            elif function == "avg":
-                data_map[key] = {"sum": value, "count": 1}
-        return data_map
+            self.update_data_map(aggregate=aggregate, row=self._initial_row)
 
     def update_data_map(self, aggregate: GlobalAggregate | GroupAggregate, row: list[str | int | bool | date]) -> None:
-        column = aggregate["column"]
+        """Fold one row into one aggregate's running value.
+
+        `count` accumulates rather than adds up, in two different ways. The **row count** (`count`,
+        `g1.count`) names no column, so nothing about the row can be missing and every row counts.
+        A **column count** (`quant.count`) counts the column's *distinct* values, so it accumulates
+        the set of them and `finalize_data_map` takes its size; a missing value is not a value, and
+        is skipped like it is for every other function.
+        """
         function = aggregate["function"]
-        index = self._column_indices[column]
-        value = row[index]
+        key = aggregate_key(aggregate)
+
+        if aggregate["column"] is None:
+            self._data_map[key] = self._data_map.get(key, 0) + 1
+            return
+
+        value = row[self._column_indices[aggregate["column"]]]
         if pd.isna(value):
             return
-        key = aggregate_key(aggregate)
-        if key not in self._data_map:
+
+        if function == "count":
+            self._data_map.setdefault(key, set()).add(value)
+        elif key not in self._data_map:
             if function in ["sum", "min", "max"]:
                 self._data_map[key] = value
-            elif function == "count":
-                self._data_map[key] = 1
             elif function == "avg":
                 self._data_map[key] = {"sum": value, "count": 1}
-        else:
-            if function == "sum":
-                self._data_map[key] += value
-            elif function == "min":
-                if value < self._data_map[key]:
-                    self._data_map[key] = value
-            elif function == "max":
-                if value > self._data_map[key]:
-                    self._data_map[key] = value
-            elif function == "count":
-                self._data_map[key] += 1
-            elif function == "avg":
-                values = self._data_map[key]
-                new_sum = values["sum"] + value
-                new_count = values["count"] + 1
-                self._data_map[key] = {"sum": new_sum, "count": new_count}
+        elif function == "sum":
+            self._data_map[key] += value
+        elif function == "min":
+            if value < self._data_map[key]:
+                self._data_map[key] = value
+        elif function == "max":
+            if value > self._data_map[key]:
+                self._data_map[key] = value
+        elif function == "avg":
+            values = self._data_map[key]
+            self._data_map[key] = {"sum": values["sum"] + value, "count": values["count"] + 1}
 
     # This must be called on all GroupedRows after they have been filtered by the WHERE and SUCH THAT clauses
-    def convert_avg_in_data_map(self) -> None:
+    def finalize_data_map(self) -> None:
+        """Turn each running accumulator into the value the query asked for: an avg's running
+        `{sum, count}` into the quotient, a column count's set of distinct values into its size.
+
+        Both conversions test the accumulator's shape rather than a flag, which makes the pass
+        idempotent: converting an avg twice used to raise "'float' object is not subscriptable".
+        """
         for aggregate in self.aggregates["global_scope"] + self.aggregates["group_specific"]:
-            if aggregate["function"] == "avg":
-                key = aggregate_key(aggregate)
-                if self._data_map.get(key):
-                    _sum, _count = self._data_map[key]["sum"], self._data_map[key]["count"]
-                    _avg = _sum / _count
-                    self._data_map[key] = _avg
+            key = aggregate_key(aggregate)
+            value = self._data_map.get(key)
+            if isinstance(value, set):
+                self._data_map[key] = len(value)
+            elif aggregate["function"] == "avg" and isinstance(value, dict):
+                self._data_map[key] = value["sum"] / value["count"]
 
     @property
     def data_map(self):

--- a/src/esql/grammar.py
+++ b/src/esql/grammar.py
@@ -15,6 +15,7 @@ exercising the parser rather than by hoping the two stay in step.
 
 from esql.parser.types import LogicalOperator
 from esql.parser.util import (
+    AGGREGATE_FORMS,
     AGGREGATE_FUNCTIONS,
     CONDITIONAL_OPERATORS,
     DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS,
@@ -34,7 +35,12 @@ from esql.parser.util import (
 # What can occupy a slot. A clause's "accepts" entry names kinds from here.
 SLOT_KINDS = {
     "column": "A column of the queried DataFrame.",
-    "aggregate": "`column.function`, or `group.column.function` for a group declared in OVER.",
+    "aggregate": (
+        "`column.function`, or `group.column.function` for a group declared in OVER. `count` alone "
+        "is the row count, naming no column, and `group.count` is that group's. With a column, "
+        "`count` counts that column's distinct values, and it is the only function legal on a "
+        "non-numeric column."
+    ),
     "group_name": "A group declared in OVER. Must match [A-Za-z0-9_]+.",
     "condition": "A comparison or semi-join, combinable with AND, OR, NOT and parentheses.",
     "group_condition": "A condition whose every column is prefixed with its group name.",
@@ -145,8 +151,14 @@ GRAMMAR = {
     "literals": LITERALS,
     "aggregates": {
         "functions": list(AGGREGATE_FUNCTIONS),
-        "forms": ["column.function", "group.column.function"],
+        # Four shapes since H4, two of which name no column. The bare ones are literal (`count`,
+        # `group.count`) because only `count` takes that form: a pattern would promise `sum` does
+        # too. A host deciding whether a projected label is a measure has to read this rather than
+        # look for a dot, since `count` is a measure and has none.
+        "forms": list(AGGREGATE_FORMS),
         "numeric_only": list(NUMERIC_AGGREGATE_FUNCTIONS),
+        # Which functions a *column* may be non-numeric for. The bare form takes no column, so it is
+        # outside this rule rather than an exception to it; see `slot_kinds["aggregate"]`.
         "any_dtype": list(DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS),
     },
     "operators": {

--- a/src/esql/parser/error.py
+++ b/src/esql/parser/error.py
@@ -14,6 +14,10 @@ class ParsingErrorType(Enum):
     # Not about a clause: a literal's delimiters are read before the query is split into clauses,
     # so there is no clause to name yet.
     STRING_LITERAL = "STRING LITERAL"
+    # Not about the query at all: the *data* uses a name the language has taken. Raised when the
+    # accessor is handed the frame, before any query exists, so it names a column rather than a
+    # token. See `accessor._reject_reserved_columns`.
+    RESERVED_COLUMN = "RESERVED COLUMN"
 
 
 class ParsingError(Exception):

--- a/src/esql/parser/parse.py
+++ b/src/esql/parser/parse.py
@@ -58,7 +58,7 @@ def _build_parsed_query(data: pd.DataFrame, query: str) -> ParsedQuery:
     column_dtypes = data.dtypes.to_dict()
     keyword_clauses = get_keyword_clauses(query)
 
-    parsed_over_clause = parse_over_clause(over_clause=keyword_clauses["OVER"])
+    parsed_over_clause = parse_over_clause(over_clause=keyword_clauses["OVER"], column_dtypes=column_dtypes)
 
     parsed_select_clause = parse_select_clause(
         select_clause=keyword_clauses["SELECT"], groups=parsed_over_clause, column_dtypes=column_dtypes

--- a/src/esql/parser/types.py
+++ b/src/esql/parser/types.py
@@ -6,7 +6,15 @@ import pandas as pd
 
 
 class GlobalAggregate(TypedDict):
-    column: str
+    """One aggregate to compute per output row.
+
+    `column` is None for the bare row count (`count`, or `g1.count` with a group), which is the one
+    aggregate that names no column: it asks how many rows the group holds, and every row holds
+    itself. Every other function needs a column, and `column.count` counts that column's *distinct*
+    values, so a column named in an aggregate always bears on the answer.
+    """
+
+    column: str | None
     function: str
 
     def __eq__(self, other):
@@ -26,7 +34,10 @@ class AggregatesDict(TypedDict):
 
 
 def aggregate_key(aggregate: GlobalAggregate | GroupAggregate) -> str:
-    """How an aggregate is spelled as a key: `column.function`, or `group.column.function`.
+    """How an aggregate is spelled as a key: the parts it has, joined by dots.
+
+    That is `column.function` or `group.column.function`, and for the bare row count, which has no
+    column, `count` or `group.count`.
 
     The parser writes these into `select_items_in_order`, `GroupedRow` keys its data map by them and
     the HAVING evaluator looks one up, so all three have to agree exactly or a projected column
@@ -34,9 +45,11 @@ def aggregate_key(aggregate: GlobalAggregate | GroupAggregate) -> str:
     because the whole query was lowercased before parsing; now that identifiers carry the frame's
     spelling, they have to be built from the same parts by the same code.
     """
-    if "group" in aggregate:
-        return f"{aggregate['group']}.{aggregate['column']}.{aggregate['function']}"
-    return f"{aggregate['column']}.{aggregate['function']}"
+    parts = [aggregate["group"]] if "group" in aggregate else []
+    if aggregate["column"] is not None:
+        parts.append(aggregate["column"])
+    parts.append(aggregate["function"])
+    return ".".join(parts)
 
 
 class LogicalOperator(Enum):

--- a/src/esql/parser/util.py
+++ b/src/esql/parser/util.py
@@ -41,13 +41,35 @@ from esql.parser.types import (
 # The six clause keywords, in the order a query must write them.
 KEYWORDS = ("SELECT", "OVER", "WHERE", "SUCH THAT", "HAVING", "ORDER BY")
 
-# The aggregate functions valid in `column.function` / `group.column.function`.
+# The aggregate functions, valid in whichever of `AGGREGATE_FORMS` below admits them.
 AGGREGATE_FUNCTIONS = ("sum", "avg", "min", "max", "count")
 
-# `count` asks how many rows, not what they hold, so it is the one function that works on any
-# dtype. `_parse_aggregate` reads this rather than naming `count` itself.
+# `column.count` asks how many distinct values a column holds, not what they are, so it is the one
+# function that works on any dtype. `_parse_aggregate` reads this rather than naming `count` itself.
 DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS = ("count",)
+
+# The functions that may be written bare, with no column: `count` on its own is the group's row
+# count, and `g1.count` is group `g1`'s. This is a different rule from the one above, which happens
+# to name the same function: that one is about which dtypes a column takes, this one about needing
+# no column at all. Nothing else can be written this way, because every other function has to be
+# told what to add up.
+#
+# It exists because the alternative was worse. Without a bare form, a row count had to borrow a
+# column (`city.count`), and under a clause that auto-groups that reads as "the cities, counted"
+# while returning the row count -- a wrong answer the syntax invites. See `.claude/status.md`, H4.
+BARE_AGGREGATE_FUNCTIONS = ("count",)
 NUMERIC_AGGREGATE_FUNCTIONS = tuple(f for f in AGGREGATE_FUNCTIONS if f not in DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS)
+
+# Every way an aggregate can be spelled, in the order `_parse_aggregate` tries them. The bare forms
+# are written out literally rather than as `function`, because only the functions above take one and
+# a pattern would promise `sum` works that way too. `GRAMMAR` publishes this list, and a host reading
+# it decides whether a projected label is a measure by matching against these shapes.
+AGGREGATE_FORMS = (
+    *BARE_AGGREGATE_FUNCTIONS,
+    *(f"group.{function}" for function in BARE_AGGREGATE_FUNCTIONS),
+    "column.function",
+    "group.column.function",
+)
 
 # Comparison operators valid in a condition. `==` is read as `=`.
 CONDITIONAL_OPERATORS = ("CONTAINS", ">=", "<=", "!=", "==", ">", "<", "=")
@@ -286,7 +308,12 @@ def parse_select_clause(
     aggregates = AggregatesDict(global_scope=[], group_specific=[])
 
     for item in (s.strip() for s in select_clause.split(",")):
-        if "." in item:
+        # A dot means an aggregate, and so does a bare `count`. The bare form is read as the row
+        # count even when the frame has a column of that name, which makes `count` a reserved word
+        # in this position: the reading has to be the same for every frame, or the same query would
+        # mean different things over different data. Such a column is still reachable everywhere
+        # else, `count.count` and `WHERE count > 5` included.
+        if "." in item or item.lower() in BARE_AGGREGATE_FUNCTIONS:
             aggregate_result = _parse_aggregate(
                 aggregate=item, groups=groups, column_dtypes=column_dtypes, error_type=ParsingErrorType.SELECT_CLAUSE
             )
@@ -300,6 +327,12 @@ def parse_select_clause(
         else:
             column = _resolve_column(item, column_dtypes, ParsingErrorType.SELECT_CLAUSE)
             if column is None:
+                # `SELECT cust, sum` is a function missing its column rather than a misspelled
+                # column, and only one of those two mistakes is worth pointing at. `count` never
+                # reaches here, so this call always raises. Checked *after* resolution, which is
+                # what keeps a column named `sum` projectable while `count` stays reserved.
+                if item.lower() in AGGREGATE_FUNCTIONS:
+                    _bare_function(item, item, ParsingErrorType.SELECT_CLAUSE)
                 raise ParsingError(ParsingErrorType.SELECT_CLAUSE, f"Invalid column: '{item}'", token=item)
             grouping_attributes.append(column)
             select_items_in_order.append(column)
@@ -769,51 +802,107 @@ def _parse_aggregate(
     column_dtypes: dict[str, np.dtype],
     error_type: ParsingErrorType,
 ) -> GlobalAggregate | GroupAggregate:
+    """Read one aggregate in any of its four forms.
+
+    `count` and `group.count` name no column: they are the row count, and the function has to be one
+    of `BARE_AGGREGATE_FUNCTIONS`. `column.function` and `group.column.function` name one, and it has
+    to exist and to suit the function's dtype rule.
+    """
     parts = aggregate.split(".")
 
-    # Format: column.aggregate_function
+    # Format: count
+    if len(parts) == 1:
+        return GlobalAggregate(column=None, function=_bare_function(parts[0], aggregate, error_type))
+
+    # Format: column.aggregate_function, or group.count
     if len(parts) == 2:
-        written_column, func = parts
-        column = _resolve_column(written_column, column_dtypes, error_type)
-        func = func.lower()
-        if column is None:
-            raise ParsingError(error_type, f"Invalid aggregate column: '{aggregate}'", token=aggregate)
-        elif func not in AGGREGATE_FUNCTIONS:
-            raise ParsingError(error_type, f"Invalid aggregate function: '{aggregate}'", token=aggregate)
-        elif func not in DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS and not (
-            pd.api.types.is_any_real_numeric_dtype(column_dtypes[column])
-        ):
-            raise ParsingError(
-                error_type, f"Invalid aggregate. Column is not a numeric type: '{aggregate}'", token=aggregate
-            )
+        written_left, written_function = parts
+        # The bare form is checked first, so `g1.count` is group `g1`'s row count even when a column
+        # is also called `g1`. The group is declared by the query itself, a few words earlier in
+        # OVER, which makes it the more deliberate of the two readings.
+        group = _resolve_group(written_left, groups)
+        if group is not None and written_function.lower() in BARE_AGGREGATE_FUNCTIONS:
+            return GroupAggregate(group=group, column=None, function=written_function.lower())
+        column, func = _aggregate_column_and_function(
+            written_column=written_left,
+            written_function=written_function,
+            aggregate=aggregate,
+            column_dtypes=column_dtypes,
+            error_type=error_type,
+        )
         return GlobalAggregate(column=column, function=func)
 
     # Format: group.column.aggregate_function
-    elif len(parts) == 3:
-        written_group, written_column, func = parts
+    if len(parts) == 3:
+        written_group, written_column, written_function = parts
         group = _resolve_group(written_group, groups)
-        column = _resolve_column(written_column, column_dtypes, error_type)
-        func = func.lower()
         if group is None:
             raise ParsingError(error_type, f"Invalid aggregate group: '{aggregate}'", token=aggregate)
-        elif column is None:
-            raise ParsingError(error_type, f"Invalid aggregate column: '{aggregate}'", token=aggregate)
-        elif func not in AGGREGATE_FUNCTIONS:
-            raise ParsingError(error_type, f"Invalid aggregate function: '{aggregate}'", token=aggregate)
-        elif func not in DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS and not (
-            pd.api.types.is_any_real_numeric_dtype(column_dtypes[column])
-        ):
-            raise ParsingError(
-                error_type, f"Invalid aggregate. Column is not a numeric type: '{aggregate}'", token=aggregate
-            )
+        column, func = _aggregate_column_and_function(
+            written_column=written_column,
+            written_function=written_function,
+            aggregate=aggregate,
+            column_dtypes=column_dtypes,
+            error_type=error_type,
+        )
         return GroupAggregate(group=group, column=column, function=func)
 
     raise ParsingError(
         error_type,
-        f"Invalid aggregate: '{aggregate}'\n"
-        "Aggregate must be in the format 'column.function' or 'group.column.function'",
+        f"Invalid aggregate: '{aggregate}'\n{_forms_sentence()}",
         token=aggregate,
     )
+
+
+def _bare_function(written_function: str, aggregate: str, error_type: ParsingErrorType) -> str:
+    """The function a bare aggregate names, or a ParsingError saying what a bare one may be.
+
+    Only `count` can stand alone, so anything else here is a function that was written without the
+    column it needs. Saying which of the two mistakes it is beats "invalid aggregate": the writer of
+    `SELECT cust, sum` meant a column and left it out.
+    """
+    func = written_function.lower()
+    if func in BARE_AGGREGATE_FUNCTIONS:
+        return func
+    if func in AGGREGATE_FUNCTIONS:
+        raise ParsingError(
+            error_type,
+            f"'{aggregate}' needs a column to aggregate: write 'column.{func}'. "
+            f"Only {', '.join(BARE_AGGREGATE_FUNCTIONS)} can be written on its own, as the row count.",
+            token=aggregate,
+        )
+    raise ParsingError(
+        error_type,
+        f"Invalid aggregate: '{aggregate}'\n{_forms_sentence()}",
+        token=aggregate,
+    )
+
+
+def _forms_sentence() -> str:
+    return "Aggregate must be in one of the forms: " + ", ".join(AGGREGATE_FORMS)
+
+
+def _aggregate_column_and_function(
+    written_column: str,
+    written_function: str,
+    aggregate: str,
+    column_dtypes: dict[str, np.dtype],
+    error_type: ParsingErrorType,
+) -> tuple[str, str]:
+    """The column and function of an aggregate that names a column, checked against each other."""
+    column = _resolve_column(written_column, column_dtypes, error_type)
+    func = written_function.lower()
+    if column is None:
+        raise ParsingError(error_type, f"Invalid aggregate column: '{aggregate}'", token=aggregate)
+    if func not in AGGREGATE_FUNCTIONS:
+        raise ParsingError(error_type, f"Invalid aggregate function: '{aggregate}'", token=aggregate)
+    if func not in DTYPE_AGNOSTIC_AGGREGATE_FUNCTIONS and not (
+        pd.api.types.is_any_real_numeric_dtype(column_dtypes[column])
+    ):
+        raise ParsingError(
+            error_type, f"Invalid aggregate. Column is not a numeric type: '{aggregate}'", token=aggregate
+        )
+    return column, func
 
 
 def _parse_condition_value(

--- a/src/esql/parser/util.py
+++ b/src/esql/parser/util.py
@@ -328,11 +328,9 @@ def parse_select_clause(
     aggregates = AggregatesDict(global_scope=[], group_specific=[])
 
     for item in (s.strip() for s in select_clause.split(",")):
-        # A dot means an aggregate, and so does a bare `count`. The bare form is read as the row
-        # count even when the frame has a column of that name, which makes `count` a reserved word
-        # in this position: the reading has to be the same for every frame, or the same query would
-        # mean different things over different data. Such a column is still reachable everywhere
-        # else, `count.count` and `WHERE count > 5` included.
+        # A dot means an aggregate, and so does a bare `count`. There is nothing else it could be:
+        # the accessor refuses a frame with a column of that name
+        # (`accessor._reject_reserved_columns`), so the word has one reading here.
         if "." in item or item.lower() in BARE_AGGREGATE_FUNCTIONS:
             aggregate_result = _parse_aggregate(
                 aggregate=item, groups=groups, column_dtypes=column_dtypes, error_type=ParsingErrorType.SELECT_CLAUSE
@@ -350,7 +348,8 @@ def parse_select_clause(
                 # `SELECT cust, sum` is a function missing its column rather than a misspelled
                 # column, and only one of those two mistakes is worth pointing at. `count` never
                 # reaches here, so this call always raises. Checked *after* resolution, which is
-                # what keeps a column named `sum` projectable while `count` stays reserved.
+                # what keeps a column named `sum` projectable: only `count` is reserved, because
+                # only `count` can be a whole aggregate on its own.
                 if item.lower() in AGGREGATE_FUNCTIONS:
                     _bare_function(item, item, ParsingErrorType.SELECT_CLAUSE)
                 raise ParsingError(ParsingErrorType.SELECT_CLAUSE, f"Invalid column: '{item}'", token=item)

--- a/src/esql/parser/util.py
+++ b/src/esql/parser/util.py
@@ -271,7 +271,14 @@ def get_keyword_clauses(query: str) -> dict[str, str | None]:
 ###########################################################################
 # OVER Clause Parsing
 ###########################################################################
-def parse_over_clause(over_clause: str | None) -> list[str]:
+def parse_over_clause(over_clause: str | None, column_dtypes: dict[str, np.dtype]) -> list[str]:
+    """The groups OVER declares, each name checked against the others and against the frame.
+
+    A group name is the query's to choose, with two names it cannot have: one already declared, and
+    one the queried data uses for a column. Both are rejected here rather than resolved later,
+    because the first thing to the left of a dot is read as a group or as a column depending on
+    which it names, and a name that is both makes `g1.count` two readings of one query.
+    """
     groups = []
     # No OVER clause means no groups, not an absent group list. Returning None here made a
     # group-prefixed aggregate written without OVER (`SELECT x, g1.y.sum`) fail the `group not in
@@ -293,8 +300,21 @@ def parse_over_clause(over_clause: str | None) -> list[str]:
                 f"case-insensitive, so these name the same group.",
                 token=group,
             )
+        if column := _column_named(group, column_dtypes):
+            raise ParsingError(
+                ParsingErrorType.OVER_CLAUSE,
+                f"Group '{group}' names the column '{column}', so '{group}.<something>' would read "
+                f"two ways. Pick a group name the data does not use.",
+                token=group,
+            )
         groups.append(group)
     return groups
+
+
+def _column_named(name: str, column_dtypes: dict[str, np.dtype]) -> str | None:
+    """The frame's spelling of the column `name` names, or None. Like `_resolve_column` but with no
+    opinion about ambiguity: any match at all is a collision, so which one it is does not matter."""
+    return next((str(column) for column in column_dtypes if str(column).lower() == name.lower()), None)
 
 
 ###########################################################################
@@ -817,9 +837,9 @@ def _parse_aggregate(
     # Format: column.aggregate_function, or group.count
     if len(parts) == 2:
         written_left, written_function = parts
-        # The bare form is checked first, so `g1.count` is group `g1`'s row count even when a column
-        # is also called `g1`. The group is declared by the query itself, a few words earlier in
-        # OVER, which makes it the more deliberate of the two readings.
+        # A name is a group or a column, never both: `parse_over_clause` rejects a group named after
+        # a column, so this is a lookup rather than a tiebreak. Deciding it here instead -- group
+        # wins, say -- would leave the query legal and its reading dependent on the frame handed in.
         group = _resolve_group(written_left, groups)
         if group is not None and written_function.lower() in BARE_AGGREGATE_FUNCTIONS:
             return GroupAggregate(group=group, column=None, function=written_function.lower())

--- a/tests/execution/test_count.py
+++ b/tests/execution/test_count.py
@@ -1,0 +1,220 @@
+"""`count` counts rows, `column.count` counts that column's distinct values (H4).
+
+The filing is worth restating because every test here is a case of it. `SELECT state, city.count`
+returned the *row* count, so CA came back as 11,963 song-performances rather than its 61 cities, and
+`song.count` and `position.count` returned that same 11,963: the column in `X.count` carried no
+meaning except its nullness. It was there to satisfy dot-notation, and under a clause that
+auto-groups, naming a column that has no bearing on the answer is what makes the answer misread.
+
+So the row count gets its own spelling, with no column to borrow, and a column named in a count now
+bears on the result. After this there is no way to write a row count that names an irrelevant column.
+
+These go through the public accessor, since what changed is what a query means.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from esql.parser.error import ParsingError
+
+
+@pytest.fixture
+def plays() -> pd.DataFrame:
+    """CA holds 3 rows over 2 cities, which is the whole filing in miniature: a row count and a
+    distinct count that disagree. `seconds` carries a blank so nullness stays visible."""
+    return pd.DataFrame(
+        {
+            "state": ["CA", "CA", "CA", "NY"],
+            "city": ["SF", "SF", "LA", "NYC"],
+            "seconds": [10.0, 20.0, None, 40.0],
+            "played": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 5, 5), date(2021, 5, 5)],
+        }
+    )
+
+
+def _for(result: pd.DataFrame, state: str, column: str):
+    return result[result["state"] == state][column].iloc[0]
+
+
+###############################################################################
+# The row count, which had no spelling at all
+###############################################################################
+def test_a_bare_count_is_the_row_count(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT state, count")
+    assert _for(result, "CA", "count") == 3
+    assert _for(result, "NY", "count") == 1
+
+
+def test_the_two_counts_disagree_which_is_the_point(plays: pd.DataFrame):
+    """3 rows over 2 cities. Before H4 both spellings answered 3, and only one of them reads as 3."""
+    result = plays.esql.query("SELECT state, count, city.count")
+    assert _for(result, "CA", "count") == 3
+    assert _for(result, "CA", "city.count") == 2
+
+
+def test_the_row_count_does_not_depend_on_any_column(plays: pd.DataFrame):
+    """The filed symptom was that `city.count`, `song.count` and `position.count` all returned the
+    same number. Now the number that is column-independent is the one that names no column."""
+    result = plays.esql.query("SELECT state, count")
+    without_a_null_column = plays.drop(columns=["seconds"]).esql.query("SELECT state, count")
+    assert list(result["count"]) == list(without_a_null_column["count"])
+
+
+def test_a_row_counts_even_where_its_values_are_missing(plays: pd.DataFrame):
+    """A blank cell makes a row no less of a row, which is why the row count cannot be `X.count` for
+    any X: `seconds.count` is 2 for CA precisely because one value is missing."""
+    result = plays.esql.query("SELECT state, count, seconds.count")
+    assert _for(result, "CA", "count") == 3
+    assert _for(result, "CA", "seconds.count") == 2
+
+
+###############################################################################
+# The distinct count
+###############################################################################
+def test_a_column_count_counts_distinct_values(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT state, city.count")
+    assert _for(result, "CA", "city.count") == 2
+
+
+def test_a_distinct_count_works_on_every_dtype(plays: pd.DataFrame):
+    """`count` is still the one function legal on a non-numeric column, which is what
+    `GRAMMAR["aggregates"]["any_dtype"]` publishes. Distinctness does not change that."""
+    result = plays.esql.query("SELECT state, city.count, played.count, seconds.count")
+    assert _for(result, "CA", "city.count") == 2
+    assert _for(result, "CA", "played.count") == 2
+    assert _for(result, "CA", "seconds.count") == 2
+
+
+def test_a_distinct_count_ignores_missing_values(plays: pd.DataFrame):
+    """A missing value is not a value, which is also what SQL's COUNT(DISTINCT x) does."""
+    assert _for(plays.esql.query("SELECT state, seconds.count"), "CA", "seconds.count") == 2
+
+
+def test_a_column_of_all_missing_values_has_no_count():
+    """No value to count is not the same as counting zero: the aggregate is absent for that row,
+    the same as any aggregate whose group matched nothing."""
+    data = pd.DataFrame({"state": ["CA", "CA"], "seconds": [None, None]})
+    assert pd.isna(data.esql.query("SELECT state, seconds.count")["seconds.count"].iloc[0])
+
+
+###############################################################################
+# Groups
+###############################################################################
+def test_a_group_takes_the_bare_form_too(plays: pd.DataFrame):
+    """`g1.count` is group `g1`'s row count, which is the symmetry `g1.column.count` implies."""
+    result = plays.esql.query("SELECT state, count, g1.count OVER g1 SUCH THAT g1.city = 'SF'")
+    assert _for(result, "CA", "count") == 3
+    assert _for(result, "CA", "g1.count") == 2
+
+
+def test_a_group_count_is_missing_when_its_section_matches_nothing(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT state, g1.count OVER g1 SUCH THAT g1.city = 'SF'")
+    assert pd.isna(_for(result, "NY", "g1.count"))
+
+
+def test_a_group_column_count_is_distinct_within_the_group(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT state, g1.city.count, g1.count OVER g1 SUCH THAT g1.seconds > 5")
+    assert _for(result, "CA", "g1.count") == 2  # the two rows with a present, matching value
+    assert _for(result, "CA", "g1.city.count") == 1  # both of them are SF
+
+
+###############################################################################
+# The other clauses
+###############################################################################
+def test_having_filters_on_a_bare_count(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT state, count HAVING count > 1")
+    assert list(result["state"]) == ["CA"]
+
+
+def test_having_filters_on_a_distinct_count(plays: pd.DataFrame):
+    assert list(plays.esql.query("SELECT state, city.count HAVING city.count > 1")["state"]) == ["CA"]
+
+
+def test_a_count_named_in_both_select_and_having_is_computed_once(plays: pd.DataFrame):
+    """BUG-8's shape. A duplicate aggregate used to be accumulated twice per row, and a row count
+    reached from two clauses is the easiest way back into that."""
+    assert _for(plays.esql.query("SELECT state, count HAVING count > 0"), "CA", "count") == 3
+
+
+def test_order_by_takes_a_bare_count(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT state, count ORDER BY -count")
+    assert list(result["state"]) == ["CA", "NY"]
+
+
+def test_a_bare_count_folds_case_like_every_other_identifier(plays: pd.DataFrame):
+    """And is labelled canonically, as v1.9.0 settled for columns and groups."""
+    result = plays.esql.query("SELECT state, COUNT, G1.Count OVER g1 SUCH THAT g1.city = 'SF'")
+    assert list(result.columns) == ["state", "count", "g1.count"]
+
+
+###############################################################################
+# What did not change
+###############################################################################
+def test_the_other_functions_still_run_over_rows(plays: pd.DataFrame):
+    result = plays.esql.query("SELECT state, seconds.sum, seconds.avg, seconds.min, seconds.max")
+    assert _for(result, "CA", "seconds.sum") == 30
+    assert _for(result, "CA", "seconds.avg") == 15
+    assert _for(result, "CA", "seconds.min") == 10
+    assert _for(result, "CA", "seconds.max") == 20
+
+
+def test_sum_over_count_is_no_longer_avg_and_avg_is_still_right(plays: pd.DataFrame):
+    """The objection raised against H4 and overruled: `sum / count` equalling `avg` is a SQL
+    identity, not a law. With `count` defined as distinct it simply does not hold, and `avg` keeps
+    its own definition rather than inheriting one."""
+    result = plays.esql.query("SELECT state, seconds.sum, seconds.count, seconds.avg")
+    data = plays[plays["state"] == "CA"]["seconds"]
+    assert _for(result, "CA", "seconds.avg") == data.mean()
+    assert _for(result, "CA", "seconds.sum") / _for(result, "CA", "seconds.count") == data.mean()
+
+    duplicated = pd.DataFrame({"state": ["CA", "CA"], "seconds": [10.0, 10.0]})
+    doubled = duplicated.esql.query("SELECT state, seconds.sum, seconds.count, seconds.avg")
+    assert doubled["seconds.avg"].iloc[0] == 10  # the mean of two tens
+    assert doubled["seconds.sum"].iloc[0] / doubled["seconds.count"].iloc[0] == 20  # 20 over 1 value
+
+
+###############################################################################
+# Refusals, and the reserved word
+###############################################################################
+@pytest.mark.parametrize("function", ["sum", "avg", "min", "max"])
+def test_every_other_function_needs_a_column(plays: pd.DataFrame, function: str):
+    with pytest.raises(ParsingError, match=f"needs a column to aggregate: write 'column.{function}'"):
+        plays.esql.query(f"SELECT state, {function}")
+
+
+def test_the_refusal_says_which_function_can_stand_alone(plays: pd.DataFrame):
+    with pytest.raises(ParsingError, match="Only count can be written on its own"):
+        plays.esql.query("SELECT state, sum")
+
+
+def test_a_bare_function_is_refused_in_having_too(plays: pd.DataFrame):
+    with pytest.raises(ParsingError, match="needs a column to aggregate"):
+        plays.esql.query("SELECT state, count HAVING sum > 1")
+
+
+def test_a_word_that_is_neither_a_column_nor_a_function_is_still_an_invalid_column(plays: pd.DataFrame):
+    with pytest.raises(ParsingError, match="Invalid column: 'nope'"):
+        plays.esql.query("SELECT state, nope")
+
+
+def test_count_is_reserved_in_select_even_when_a_column_is_called_count():
+    """The reading cannot depend on the frame, or the same query would mean different things over
+    different data. So the bare word is the row count, and the column is reached by naming it in an
+    aggregate or a condition, where nothing else could be meant."""
+    data = pd.DataFrame({"state": ["CA", "CA"], "count": [7, 7]})
+    assert data.esql.query("SELECT state, count")["count"].iloc[0] == 2  # rows, not the column
+    assert data.esql.query("SELECT state, count.count")["count.count"].iloc[0] == 1  # one distinct 7
+    assert data.esql.query("SELECT state, count.sum")["count.sum"].iloc[0] == 14
+    assert len(data.esql.query("SELECT state, count WHERE count > 5")) == 1
+
+
+def test_a_column_named_for_another_function_stays_projectable():
+    """Only the bare forms are reserved. `sum` is not one, so a column of that name is still a
+    grouping attribute -- the check that refuses `SELECT state, sum` runs only once the word has
+    failed to name a column."""
+    data = pd.DataFrame({"state": ["CA"], "sum": [7]})
+    assert list(data.esql.query("SELECT state, sum").columns) == ["state", "sum"]

--- a/tests/execution/test_count.py
+++ b/tests/execution/test_count.py
@@ -210,20 +210,37 @@ def test_a_word_that_is_neither_a_column_nor_a_function_is_still_an_invalid_colu
         plays.esql.query("SELECT state, nope")
 
 
-def test_count_is_reserved_in_select_even_when_a_column_is_called_count():
-    """The reading cannot depend on the frame, or the same query would mean different things over
-    different data. So the bare word is the row count, and the column is reached by naming it in an
-    aggregate or a condition, where nothing else could be meant."""
+def test_a_frame_with_a_column_called_count_is_refused():
+    """`count` means the row count wherever a column could go, so a column of that name is a word
+    with two readings and no way for a query writer to say which. Preferring one would make
+    `SELECT venue, count` mean different things over different data; preferring the other would put
+    the row count out of reach for that frame alone. The name is refused where it was chosen."""
     data = pd.DataFrame({"state": ["CA", "CA"], "count": [7, 7]})
-    assert data.esql.query("SELECT state, count")["count"].iloc[0] == 2  # rows, not the column
-    assert data.esql.query("SELECT state, count.count")["count.count"].iloc[0] == 1  # one distinct 7
-    assert data.esql.query("SELECT state, count.sum")["count.sum"].iloc[0] == 14
-    assert len(data.esql.query("SELECT state, count WHERE count > 5")) == 1
+    with pytest.raises(ParsingError, match="Rename the column in the data"):
+        data.esql.query("SELECT state")
 
 
-def test_a_column_named_for_another_function_stays_projectable():
-    """Only the bare forms are reserved. `sum` is not one, so a column of that name is still a
-    grouping attribute -- the check that refuses `SELECT state, sum` runs only once the word has
-    failed to name a column."""
+def test_the_frame_is_refused_before_any_query_is_read():
+    """At the accessor, not at the reference: a query that never writes the word is refused too,
+    which is what makes the message about the data rather than about the query."""
+    data = pd.DataFrame({"state": ["CA"], "count": [7]})
+    with pytest.raises(ParsingError, match="named after the aggregate"):
+        data.esql.validate("SELECT state")
+    with pytest.raises(ParsingError, match="named after the aggregate"):
+        data.esql  # noqa: B018 -- constructing the accessor is where the check runs
+
+
+@pytest.mark.parametrize("spelling", ["Count", "COUNT"])
+def test_the_reserved_name_is_refused_in_any_case(spelling: str):
+    """Identifiers fold case, so a differently cased column is the same collision."""
+    with pytest.raises(ParsingError, match=f"Column '{spelling}'"):
+        pd.DataFrame({"state": ["CA"], spelling: [7]}).esql.query("SELECT state")
+
+
+def test_a_column_named_for_another_function_is_left_alone():
+    """Only a name that can be a whole aggregate is reserved. `sum` is never one on its own, so it
+    has a single reading as a column and the frame is accepted: `SELECT state, sum` projects it, and
+    the refusal for a missing column runs only once the word has failed to name one."""
     data = pd.DataFrame({"state": ["CA"], "sum": [7]})
     assert list(data.esql.query("SELECT state, sum").columns) == ["state", "sum"]
+    assert data.esql.query("SELECT state, sum.sum")["sum.sum"].iloc[0] == 7

--- a/tests/execution/test_count.py
+++ b/tests/execution/test_count.py
@@ -116,6 +116,15 @@ def test_a_group_count_is_missing_when_its_section_matches_nothing(plays: pd.Dat
     assert pd.isna(_for(result, "NY", "g1.count"))
 
 
+def test_a_group_cannot_be_named_after_a_column(plays: pd.DataFrame):
+    """H4 is what makes this collision matter. `g1.count` is a group's row count, and if `g1` were
+    also a column the same words would equally be that column's distinct count -- a query whose
+    meaning depends on the frame it is handed. The name is refused where the query chooses it,
+    rather than one reading being preferred at every reference."""
+    with pytest.raises(ParsingError, match="names the column 'city'"):
+        plays.esql.query("SELECT state, city.count OVER city SUCH THAT city.seconds > 5")
+
+
 def test_a_group_column_count_is_distinct_within_the_group(plays: pd.DataFrame):
     result = plays.esql.query("SELECT state, g1.city.count, g1.count OVER g1 SUCH THAT g1.seconds > 5")
     assert _for(result, "CA", "g1.count") == 2  # the two rows with a present, matching value

--- a/tests/execution/test_execution_integration.py
+++ b/tests/execution/test_execution_integration.py
@@ -122,13 +122,40 @@ def test_gt_date_where_query(sales_test_data: pd.DataFrame):
 @pytest.mark.timeout(5)
 def test_eq_date_where_query(sales_test_data: pd.DataFrame):
     sql = """
-        select cust,prod, count(month) from sales
+        select cust,prod, count(distinct month) from sales
         where date = '2020-04-13'
         group by cust, prod
     """
     esql = """
         SELECT cust, prod, month.count
         where date = '2020-4-13'
+    """
+    _test_query(sql, esql, data=sales_test_data)
+
+
+@pytest.mark.timeout(5)
+def test_row_count_query(sales_test_data: pd.DataFrame):
+    # H4's two counts against the two SQL spells them with. A bare `count` is COUNT(*), which is
+    # what ESQL had no way to write before, and it differs from the distinct count below on this
+    # data -- so a test that agreed with both would be proving nothing.
+    sql = """
+        select cust, prod, count(*) from sales
+        group by cust, prod
+    """
+    esql = """
+        SELECT cust, prod, count
+    """
+    _test_query(sql, esql, data=sales_test_data)
+
+
+@pytest.mark.timeout(5)
+def test_distinct_count_query(sales_test_data: pd.DataFrame):
+    sql = """
+        select cust, prod, count(distinct state) from sales
+        group by cust, prod
+    """
+    esql = """
+        SELECT cust, prod, state.count
     """
     _test_query(sql, esql, data=sales_test_data)
 
@@ -257,19 +284,19 @@ def test_mf_query_with_where(sales_test_data: pd.DataFrame):
             GROUP BY cust, prod
         ),
         old AS (
-            SELECT cust, prod , sum(quant) as sum, count(quant) as count
+            SELECT cust, prod , sum(quant) as sum, count(distinct quant) as count
             FROM sales
             WHERE date < '2017-01-01' and credit = true
             GROUP BY cust, prod
         ),
         newer AS (
-            SELECT cust, prod, sum(quant) as sum, count(quant) as count
+            SELECT cust, prod, sum(quant) as sum, count(distinct quant) as count
             FROM sales
             WHERE date >= '2017-01-01' and date < '2018-12-31' and credit = true
             GROUP BY cust, prod
         ),
         new AS (
-            SELECT cust, prod , sum(quant) as sum, count(quant) as count
+            SELECT cust, prod , sum(quant) as sum, count(distinct quant) as count
             FROM sales
             WHERE date >= '2018-12-31' and credit = true
             GROUP BY cust, prod

--- a/tests/execution/test_execution_unit.py
+++ b/tests/execution/test_execution_unit.py
@@ -195,6 +195,34 @@ def test_order_by_sort_with_numeric_attribute():
     )
 
 
+def test_finalizing_twice_leaves_the_same_values():
+    """`finalize_data_map` dispatches on the accumulator's shape rather than on a flag, which is what
+    makes a second pass a no-op. The flagged version raised "'float' object is not subscriptable" on
+    an avg converted twice, which is how BUG-8's duplicate aggregate showed up."""
+    aggregates: AggregatesDict = {
+        "global_scope": [
+            {"column": "quant", "function": "avg"},
+            {"column": "quant", "function": "count"},
+            {"column": None, "function": "count"},
+        ],
+        "group_specific": [],
+    }
+    row = GroupedRow(
+        grouping_attributes=["cust"],
+        aggregates=aggregates,
+        initial_row=["Alice", 10.0],
+        column_indices={"cust": 0, "quant": 1},
+    )
+    row.update_data_map(aggregates["global_scope"][0], ["Alice", 20.0])
+    row.finalize_data_map()
+    finalized = dict(row.data_map)
+    row.finalize_data_map()
+    assert row.data_map == finalized
+    assert finalized["quant.avg"] == 15
+    assert finalized["quant.count"] == 1
+    assert finalized["count"] == 1
+
+
 def test_projection_rounds_correctly():
     grouping_attributes = ["cust", "prod"]
     column_indices = {"cust": 0, "prod": 1, "quant1": 2, "quant2": 3}
@@ -214,6 +242,9 @@ def test_projection_rounds_correctly():
         initial_row=initial_row,
         column_indices=column_indices,
     )
+    # As `build_grouped_table` does before projecting: a count is a set of distinct values and an
+    # avg a running {sum, count} until this pass turns each into the number the query asked for.
+    row.finalize_data_map()
     table = [row]
     parsed_select_clause = ParsedSelectClause(
         grouping_attributes=grouping_attributes,

--- a/tests/execution/test_null_operands.py
+++ b/tests/execution/test_null_operands.py
@@ -27,22 +27,22 @@ def segue_data() -> pd.DataFrame:
 
 def test_where_equality_on_nullable_column_does_not_raise(segue_data: pd.DataFrame):
     # came_from is NA for the cold opens; `= 'Scarlet'` must skip those rows, not raise.
-    result = segue_data.esql.query("SELECT song, seconds.count WHERE came_from = 'Scarlet' ORDER BY 1")
+    result = segue_data.esql.query("SELECT song, count WHERE came_from = 'Scarlet' ORDER BY 1")
     assert set(result["song"]) == {"Fire"}
-    assert result[result["song"] == "Fire"]["seconds.count"].iloc[0] == 2
+    assert result[result["song"] == "Fire"]["count"].iloc[0] == 2
 
 
 def test_where_inequality_on_nullable_column_excludes_nulls(segue_data: pd.DataFrame):
     # SQL NULL semantics: an NA operand compares as not-true, so `!= 'Scarlet'` keeps only the
     # present, non-matching rows (Cold Rain), never the NA rows.
-    result = segue_data.esql.query("SELECT came_from, seconds.count WHERE came_from != 'Scarlet'")
+    result = segue_data.esql.query("SELECT came_from, count WHERE came_from != 'Scarlet'")
     assert set(result["came_from"]) == {"Cold Rain"}
 
 
 def test_order_by_grouping_column_with_null_bucket_sorts_nulls_last(segue_data: pd.DataFrame):
     # Grouping by the nullable column keeps a null bucket (the cold opens); ORDER BY must place it
     # last without raising.
-    result = segue_data.esql.query("SELECT came_from, seconds.count WHERE song = 'Fire' ORDER BY 1")
+    result = segue_data.esql.query("SELECT came_from, count WHERE song = 'Fire' ORDER BY 1")
     assert result["came_from"].isna().any(), "the null bucket must survive"
     assert pd.isna(result["came_from"].iloc[-1]), "nulls sort last"
     # present value 'Scarlet' (2 Fires) + the null bucket (1 cold-open Fire)
@@ -52,7 +52,7 @@ def test_order_by_grouping_column_with_null_bucket_sorts_nulls_last(segue_data: 
 def test_such_that_condition_on_nullable_column_does_not_raise(segue_data: pd.DataFrame):
     # A SUCH THAT group scoped by the nullable column: NA rows drop from that group instead of
     # raising, exactly like WHERE. Only Fire has came_from == 'Scarlet' rows (two of them).
-    esql = "SELECT song, g.seconds.count OVER g SUCH THAT g.came_from = 'Scarlet' ORDER BY 1"
+    esql = "SELECT song, g.count OVER g SUCH THAT g.came_from = 'Scarlet' ORDER BY 1"
     result = segue_data.esql.query(esql)
     fire = result[result["song"] == "Fire"]
-    assert fire["g.seconds.count"].iloc[0] == 2
+    assert fire["g.count"].iloc[0] == 2

--- a/tests/execution/test_order_by_terms.py
+++ b/tests/execution/test_order_by_terms.py
@@ -3,7 +3,7 @@
 Before this, ORDER BY took one number meaning "the first N grouping attributes", so the second half
 of the first question anyone asks of a dataset -- having counted something, sort by the count --
 could not be written at all. Widening the number would not have fixed it: the sort it describes
-always starts at the first grouping attribute, so `SELECT song, song.count ORDER BY 2` would sort by
+always starts at the first grouping attribute, so `SELECT song, count ORDER BY 2` would sort by
 song and then by the count, never by the count alone.
 
 These go through the public accessor, since the point is what a query can now express.
@@ -40,27 +40,27 @@ def _rows(result: pd.DataFrame, column: str = "song") -> list:
 ###############################################################################
 def test_sorting_by_an_aggregate_descending(plays: pd.DataFrame):
     """"Which did they play most" -- the query H3 was filed for."""
-    result = plays.esql.query("SELECT song, seconds.count ORDER BY -seconds.count")
+    result = plays.esql.query("SELECT song, count ORDER BY -count")
     assert _rows(result)[0] == "Truckin"
-    assert list(result["seconds.count"]) == [3, 2, 2]
+    assert list(result["count"]) == [3, 2, 2]
 
 
 def test_sorting_by_an_aggregate_ascending(plays: pd.DataFrame):
-    result = plays.esql.query("SELECT song, seconds.count ORDER BY seconds.count")
-    assert list(result["seconds.count"]) == [2, 2, 3]
+    result = plays.esql.query("SELECT song, count ORDER BY count")
+    assert list(result["count"]) == [2, 2, 3]
 
 
 def test_a_second_term_breaks_the_tie(plays: pd.DataFrame):
     """Two songs have 2 plays each, so the count alone does not determine the order and `song` does."""
-    result = plays.esql.query("SELECT song, seconds.count ORDER BY -seconds.count, song")
+    result = plays.esql.query("SELECT song, count ORDER BY -count, song")
     assert _rows(result) == ["Truckin", "Dark Star", "Sugaree"]
 
 
 def test_each_term_carries_its_own_direction(plays: pd.DataFrame):
     """The count descending, the tie broken descending: the pair a single reversed sort cannot make,
     since one `reverse` flips every key at once."""
-    ascending_name = plays.esql.query("SELECT song, seconds.count ORDER BY -seconds.count, song")
-    descending_name = plays.esql.query("SELECT song, seconds.count ORDER BY -seconds.count, -song")
+    ascending_name = plays.esql.query("SELECT song, count ORDER BY -count, song")
+    descending_name = plays.esql.query("SELECT song, count ORDER BY -count, -song")
     assert _rows(ascending_name) == ["Truckin", "Dark Star", "Sugaree"]
     assert _rows(descending_name) == ["Truckin", "Sugaree", "Dark Star"]
 

--- a/tests/parser/test_grammar.py
+++ b/tests/parser/test_grammar.py
@@ -20,6 +20,7 @@ from esql.grammar import GRAMMAR
 from esql.parser.error import ParsingError
 from esql.parser.util import (
     AGGREGATE_FUNCTIONS,
+    BARE_AGGREGATE_FUNCTIONS,
     CONDITIONAL_OPERATORS,
     DTYPE_FAMILIES,
     KEYWORDS,
@@ -120,10 +121,47 @@ def test_dtype_agnostic_aggregates_accept_a_text_column(function: str, data: pd.
 
 
 @pytest.mark.parametrize("form", GRAMMAR["aggregates"]["forms"])
-def test_both_aggregate_forms_parse(form: str, data: pd.DataFrame):
+def test_every_aggregate_form_parses(form: str, data: pd.DataFrame):
     aggregate = form.replace("group", "g1").replace("column", "quant").replace("function", "sum")
-    over = " OVER g1" if "g1." in aggregate else ""
+    over = " OVER g1" if aggregate.startswith("g1.") else ""
     data.esql.validate(f"SELECT cust, {aggregate}{over}")
+
+
+@pytest.mark.parametrize("form", [form for form in GRAMMAR["aggregates"]["forms"] if "column" not in form])
+def test_a_form_that_names_no_column_is_the_row_count(form: str):
+    """The published forms are the four shapes, and two of them carry no column. That is a claim
+    about meaning, not just about parsing: the number they return has to be the row count, or the
+    bare form is just another spelling of something that borrows a column."""
+    data = pd.DataFrame({"cust": ["a", "a", "b"], "quant": [1, 1, 2]})
+    aggregate = form.replace("group", "g1")
+    over = " OVER g1 SUCH THAT g1.quant > 0" if aggregate.startswith("g1.") else ""
+    result = data.esql.query(f"SELECT cust, {aggregate}{over}")
+    assert list(result[aggregate]) == [2, 1]
+
+
+def test_every_function_that_can_stand_alone_has_both_of_its_forms_published():
+    """The parser reads `BARE_AGGREGATE_FUNCTIONS` for legality and `forms` is what a host reads to
+    offer them, so a form dropped from the list is surface the parser accepts and nobody can find.
+    Parametrizing over `forms` cannot catch that: removing an entry removes its test with it."""
+    forms = GRAMMAR["aggregates"]["forms"]
+    for function in BARE_AGGREGATE_FUNCTIONS:
+        assert function in forms, f"{function} can stand alone and no form says so"
+        assert f"group.{function}" in forms, f"{function} can stand alone in a group and no form says so"
+
+
+def test_a_column_count_counts_distinct_values_as_described(data: pd.DataFrame):
+    """`slot_kinds["aggregate"]` says the column form counts distinct values, which is what makes
+    the column in it bear on the answer at all. Two identical values, one count."""
+    assert "distinct values" in GRAMMAR["slot_kinds"]["aggregate"]
+    repeated = pd.DataFrame({"cust": ["a", "a"], "prod": ["x", "x"]})
+    assert repeated.esql.query("SELECT cust, prod.count")["prod.count"].iloc[0] == 1
+
+
+def test_the_any_dtype_rule_governs_the_column_form_only(data: pd.DataFrame):
+    """The narrowing H4 forced. `any_dtype` says which functions a non-numeric *column* may be
+    given, and the bare form gives none, so it sits outside the rule rather than inside it."""
+    for function in GRAMMAR["aggregates"]["numeric_only"]:
+        assert function not in GRAMMAR["aggregates"]["forms"], f"{function} claims a form with no column"
 
 
 def test_such_that_requires_over_as_described(data: pd.DataFrame):

--- a/tests/parser/test_util.py
+++ b/tests/parser/test_util.py
@@ -133,20 +133,29 @@ def test_get_keyword_clauses_raises_error_for_missing_arguments_after_select():
 ###########################################################################
 # PARSE_OVER_CLAUSE TESTS
 ###########################################################################
-def test_parse_over_clause_returns_expected_structure():
+def test_parse_over_clause_returns_expected_structure(column_dtypes: dict[str, np.dtype]):
     parsedOverClause = parse_over_clause(
-        over_clause="Apples  ,   132537aaGGG, ___yuetsg___8   ,   728x2fegoql,   GGGGGGHHHHH_____   "
+        over_clause="Apples  ,   132537aaGGG, ___yuetsg___8   ,   728x2fegoql,   GGGGGGHHHHH_____   ",
+        column_dtypes=column_dtypes,
     )
     expected = ["Apples", "132537aaGGG", "___yuetsg___8", "728x2fegoql", "GGGGGGHHHHH_____"]
     assert parsedOverClause == expected
 
 
-def test_parse_over_clause_raises_error_for_invalid_characters():
+def test_parse_over_clause_raises_error_for_invalid_characters(column_dtypes: dict[str, np.dtype]):
     invalid_groups = ["aa)hhhd", "$teven", "#678", "[george]", "wow!"]
     for group in invalid_groups:
         with pytest.raises(ParsingError) as parsingError:
-            parse_over_clause(over_clause=f"{group}")
+            parse_over_clause(over_clause=f"{group}", column_dtypes=column_dtypes)
         assert parsingError.value.error_type == ParsingErrorType.OVER_CLAUSE
+
+
+def test_parse_over_clause_rejects_a_group_named_after_a_column(column_dtypes: dict[str, np.dtype]):
+    """A name cannot be both, or the first thing to the left of a dot reads two ways. Rejected at
+    the declaration, where the query says which names it wants, rather than resolved per reference."""
+    for group in ["quant", "QUANT"]:
+        with pytest.raises(ParsingError, match="names the column"):
+            parse_over_clause(over_clause=group, column_dtypes=column_dtypes)
 
 
 ###########################################################################

--- a/tests/test_syntax_docs.py
+++ b/tests/test_syntax_docs.py
@@ -1,0 +1,178 @@
+"""Assert `public/docs/syntax.md` against `GRAMMAR` (G2).
+
+The doc is prose and stays prose: nothing here rewrites it, and it is free to explain, motivate and
+give examples in whatever words suit. What it is not free to do is *restate a rule wrongly*, which
+is what J5 cost when a `summary` string described an escape the parser does not implement, and what
+G3 found when the front end offered `song >` because nothing published the dtype axis.
+
+So the guard is scoped to claims, and a claim is marked as one. `<!-- grammar:operators WHERE -->`
+in front of a paragraph says "the operators named here are WHERE's operators", and this file checks
+that against the parser's own token sets. Prose with no marker is not checked, because a regex over
+English produces false positives and a gate that cries wolf gets bypassed.
+
+Two directions matter and they catch different mistakes:
+
+- **What the doc claims must be legal.** A marked list offering an operator the clause rejects sends
+  a reader to write a query that does not parse.
+- **What is legal must be documented.** An operator added to a clause and never written down is the
+  silent half, and the one no reader can report.
+
+The second is deliberately looser about *where*: it asks that the operator appear somewhere in that
+clause's section, because the doc legitimately introduces `==` and `HAS` in their own paragraphs
+rather than in the list.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from esql.grammar import GRAMMAR
+from esql.parser.util import (
+    AGGREGATE_FUNCTIONS,
+    KEYWORDS,
+    OPERATOR_DTYPES,
+    QUOTE_CHARACTERS,
+    SEMI_JOIN_OPERATOR,
+)
+
+SYNTAX_DOC = Path(__file__).resolve().parent.parent / "public" / "docs" / "syntax.md"
+DOC = SYNTAX_DOC.read_text()
+
+ALL_OPERATORS = {*GRAMMAR["operators"]["comparison"], SEMI_JOIN_OPERATOR}
+# The doc writes text as "text" where the engine's dtype family is "string". One rename, declared.
+DOC_DTYPE_NAMES = {"number": "number", "date": "date", "string": "text", "boolean": "boolean"}
+
+
+def _backticked(text: str) -> list[str]:
+    return re.findall(r"`([^`]+)`", text)
+
+
+def _marked_span(marker: str) -> str:
+    """The block following `<!-- grammar:<marker> -->`, up to the next blank line.
+
+    A marker claims exactly the block it sits in front of, which is what keeps the guard from
+    reading the paragraph after it as part of the claim.
+    """
+    opening = f"<!-- grammar:{marker} -->"
+    assert opening in DOC, f"{SYNTAX_DOC.name} no longer marks '{marker}'. A claim cannot go unguarded by deleting its marker."
+    body = DOC.split(opening, 1)[1].lstrip("\n")
+    return body.split("\n\n", 1)[0]
+
+
+def _operator_claim(clause: str) -> tuple[set[str], set[str]]:
+    """What `<!-- grammar:operators <clause> also:a,b -->` claims: the operators in the block it
+    precedes, and the ones it declares are documented elsewhere in the section."""
+    pattern = rf"<!-- grammar:operators {re.escape(clause)}(?: also:([^ ]+))? -->\n(.*?)(?:\n\n|$)"
+    match = re.search(pattern, DOC, flags=re.DOTALL)
+    assert match, f"{SYNTAX_DOC.name} no longer marks {clause}'s operators. A claim cannot go unguarded by deleting its marker."
+    also = {token for token in (match.group(1) or "").split(",") if token}
+    listed = {token for token in _backticked(match.group(2)) if token in ALL_OPERATORS}
+    return listed, also
+
+
+def _section(keyword: str) -> str:
+    """One clause's whole section, subsections included."""
+    heading = f"\n## {keyword}\n"
+    assert heading in DOC, f"{SYNTAX_DOC.name} has no section for {keyword}"
+    body = DOC.split(heading, 1)[1]
+    return body.split("\n## ", 1)[0]
+
+
+###############################################################################
+# Structure
+###############################################################################
+def test_every_keyword_has_a_section_in_the_documented_order():
+    headings = re.findall(r"^## (.+)$", DOC, flags=re.MULTILINE)
+    clause_headings = [heading for heading in headings if heading in KEYWORDS]
+    assert clause_headings == list(KEYWORDS)
+
+
+def test_the_keyword_list_names_every_keyword_and_counts_them_right():
+    span = _marked_span("keywords")
+    assert _backticked(span) == list(KEYWORDS)
+    assert f"has {len(KEYWORDS)} keywords" in span, "the count in the prose disagrees with KEYWORDS"
+
+
+###############################################################################
+# Operators, both directions
+###############################################################################
+@pytest.mark.parametrize("clause", ["WHERE", "SUCH THAT", "HAVING"])
+def test_a_clause_documents_exactly_the_operators_it_accepts(clause: str):
+    """Both directions at once, which is the only way that holds.
+
+    The obvious looser check -- "every legal operator appears somewhere in the clause's section" --
+    does not work, and testing it proved it: giving HAVING the `HAS` operator passed, because
+    HAVING's section does mention `HAS`, in a sentence saying it is rejected. A mention that says
+    the opposite still counts as a mention.
+
+    So the marker carries the whole claim. The list it precedes is the claim, and `also:` names the
+    operators documented elsewhere in the section, each of which still has to be found there. An
+    operator that becomes legal is then undeclared until someone writes it down on purpose.
+    """
+    listed, also = _operator_claim(clause)
+    assert listed, f"the marked list for {clause} names no operators"
+
+    section = set(_backticked(_section(clause)))
+    for operator in also:
+        assert operator in section, f"{clause} declares `{operator}` documented elsewhere, and its section never writes it"
+
+    assert listed | also == set(GRAMMAR["clauses"][clause]["operators"])
+
+
+###############################################################################
+# The tables that restate a published rule outright
+###############################################################################
+def test_the_operator_dtype_table_matches_the_rule_the_parser_enforces():
+    """The newest hand-written mirror, and the one with the most to get wrong: four rows and three
+    columns of yes/no that `OPERATOR_DTYPES` already answers."""
+    rows = [row for row in _marked_span("operator-dtypes").splitlines() if row.startswith("|")]
+    header, _separator, *body = rows
+    column_operators = [_backticked(cell) for cell in header.split("|")[2:-1]]
+    assert column_operators, "the dtype table has no operator columns"
+
+    documented: dict[str, set[str]] = {operator: set() for group in column_operators for operator in group}
+    for row in body:
+        cells = [cell.strip() for cell in row.split("|")[1:-1]]
+        family = cells[0]
+        for group, verdict in zip(column_operators, cells[1:], strict=True):
+            assert verdict in ("yes", "no"), f"unreadable verdict {verdict!r} for {family}"
+            if verdict == "yes":
+                for operator in group:
+                    documented[operator].add(family)
+
+    for operator, families in documented.items():
+        real = {DOC_DTYPE_NAMES[family] for family in OPERATOR_DTYPES[operator]}
+        assert families == real, f"the table says {operator} takes {sorted(families)}, the parser takes {sorted(real)}"
+
+
+def test_every_operator_with_a_dtype_rule_appears_in_the_table():
+    """`==` is the one comparison the table leaves out, and the doc says elsewhere that it reads as
+    `=`. Anything else missing is a rule with no row."""
+    header = _marked_span("operator-dtypes").splitlines()[0]
+    tabled = {operator for cell in header.split("|")[2:-1] for operator in _backticked(cell)}
+    assert set(OPERATOR_DTYPES) - tabled == {"=="}
+
+
+###############################################################################
+# Aggregates and literals
+###############################################################################
+def test_the_aggregate_function_list_is_the_real_one():
+    # Deduped, since the paragraph names `count` again to say it is the one that takes any dtype.
+    listed = dict.fromkeys(
+        token for token in _backticked(_marked_span("aggregate-functions")) if token in AGGREGATE_FUNCTIONS
+    )
+    assert list(listed) == list(AGGREGATE_FUNCTIONS)
+
+
+def test_the_documented_aggregate_forms_are_the_published_ones():
+    span = _marked_span("aggregate-functions")
+    for form in GRAMMAR["aggregates"]["forms"]:
+        assert f"`{form}`" in span, f"the aggregate form {form} is published and undocumented"
+
+
+def test_the_documented_text_delimiters_are_the_real_ones():
+    delimiters = {token for token in _backticked(_marked_span("text-delimiters")) if token in QUOTE_CHARACTERS}
+    assert delimiters == set(QUOTE_CHARACTERS)

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.13.0"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.14.0"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
Two releases on one branch. G2 closes Stream G, H4 closes Stream H.

## v1.14.0 — the prose is bound to the grammar (G2)

`tests/test_syntax_docs.py` asserts `public/docs/syntax.md` against `GRAMMAR` and the parser's token sets. Asserted rather than generated: the doc's value is the half no export can hold (what a clause is *for*), so prose stays hand-written and only the parts that *restate a rule* are bound.

A claim is marked as one — `<!-- grammar:operators WHERE also:==,HAS -->`. Six markers: keywords, aggregate functions, the three clause operator lists, the operator-dtype table, the text delimiters. Unmarked prose is unchecked, because a regex over English produces false positives and a gate that cries wolf gets bypassed.

The loose version of this test does not work, and writing it proved that. "Does every legal operator appear somewhere in the clause's section" passes when HAVING gains `HAS`, because HAVING's section *does* mention `HAS` — in a sentence saying it is rejected. A mention that says the opposite still counts as a mention. So the marker carries the whole claim: the list plus its `also:` set must equal the clause's operators exactly.

Guards verified to bite seven ways, including a deleted marker — a claim cannot go unguarded by quietly removing it.

## v1.15.0 — `count` counts rows, `column.count` counts distinct (H4)

```sh
SELECT cust, count              -- how many rows this customer has
SELECT cust, prod.count         -- how many distinct products
SELECT cust, g1.count OVER g1 SUCH THAT g1.state = 'NY'   -- how many rows in the group
```

What was wrong was an answer, not an error. `city.count`, `song.count` and `position.count` all returned the row count, because the column in `X.count` carried no meaning except its nullness. The root cause was a missing spelling: ESQL had no `COUNT(*)`, so every row count borrowed a column and dot-notation turned the borrowed name into an apparent meaning.

Two collision rules, landing on the same answer from opposite directions — a name the language reads two ways is refused where it is written down:

- **`count` is reserved; a frame with a `count` column is refused** (`ParsingErrorType.RESERVED_COLUMN`, raised at `df.esql`, before any query exists). Preferring the aggregate leaves `SELECT venue, count` meaning different things over different data; preferring the column puts the row count out of reach. Both are invisible to whoever writes the query. Only names that can be a *whole* aggregate are taken, so a column may still be called `sum`.
- **A group cannot be named after a column.** The first cut preferred the group; that left the query legal and its meaning dependent on the frame handed in, which is the failure H4 exists to remove.

`sum / count` is no longer `avg`, pinned by a test so nobody restores it by "fixing" avg. A distinct count skips blanks; a row count does not.

Validated against sqlite, not just against itself: two parity tests pin the two counts to `COUNT(*)` and `COUNT(DISTINCT state)`, and they disagree on that data, so a test agreeing with both would prove nothing.

**Verified the guards bite, and two did not at first.** Dropping a bare form from `forms` *passed* — the test is parametrized over the list, so deleting an entry deletes its own test. Worth watching for anywhere a published list drives its own coverage; it is now bound to `BARE_AGGREGATE_FUNCTIONS`. Idempotence passed too, because nothing called the finalize pass twice; it has a real test now.

## Gate

`make check` green at **428 tests** (was 376 at the branch point).

## Downstream, required

The H4 migration is portfolio's: all 13 curated examples borrow `position` for a row count and now answer the distinct count instead. They still parse, so nothing fails loudly — `esql-smoke` is what catches it. `RESERVED_COLUMN` is a new `error_type` its funnel needs a case for. The result table must read `forms` rather than looking for a dot, or a bare `count` column is filed as a dimension. Land it with D1.