### PR TITLE
v1.15.1: delete two __eq__ methods that could never run (L2, closes Stream L)

### DIFF
--- a/.claude/status.md
+++ b/.claude/status.md
@@ -395,6 +395,40 @@ patched twice.
 
 ---
 
+## Stream L — claims the type system makes
+
+Opened 2026-07-31, and closed the same day by v1.15.1. Findings from asking why `make typecheck`
+reported 152 errors when the suite was green. The answer is that **the count was never a count of
+problems** (61 lines produced 153 errors, because comparing two union-typed operands reports every
+illegal pairing), but two of the things it was pointing at were real, and both are the shape this
+repo keeps finding: **a claim written down that nothing binds, which is therefore free to be false.**
+
+The type annotations were the last unbound claim surface. `GRAMMAR` is bound to the parser (G1),
+`syntax.md` is bound to `GRAMMAR` (G2), and `literals.text.summary` was bound after J5 caught it
+lying. A type annotation is the same kind of statement -- it says what a value is -- and until
+`typecheck` is clean nothing checks it, so it drifts exactly like prose does.
+
+- [x] **L1. `_data_map`'s annotation was false, and its own release made it false.** Shipped in
+  v1.15.0 before merge; see that entry in the settled record. The slot was declared
+  `dict[str, str | int | bool | date]` while holding a `set` (the distinct count v1.15.0 had just
+  added), a running `{"sum", "count"}` dict, and floats. The union was also wrong about `float` at
+  all nine sites that spelled it out, which is older: a float column is ordinary, so `quant.sum`
+  over one always returned a value the type called impossible.
+
+- [x] **L2. Two `__eq__` methods that never ran, on the types the aggregate merge compares.**
+  Shipped in v1.15.1; see that entry in the settled record. Same shape as **K2**'s dead `A or B`
+  defaults -- a line that looks like it selects behavior and does not -- but sitting on the code path
+  whose bug was BUG-8's silent doubling, which makes it worth more than tidiness.
+
+**What to look for next, since this is now the third instance.** K2, L1 and L2 are all *a second
+statement of a rule that no longer had to agree with the first*. The remaining mypy clusters are
+the same bet: 30 `[arg-type]` and 17 `[typeddict-item]` say the parsed-condition shapes are modelled
+in a way the code does not follow, which the mypy item above proposes fixing by moving them from
+TypedDicts to dataclasses. That is worth doing for the reason G1 was worth doing, not for the error
+count.
+
+---
+
 ## Toolchain note — always `uv run python -m <tool>`
 
 `uv run pytest` does **not** run this project's pytest. The console script fails to spawn under the
@@ -1191,6 +1225,41 @@ All fixed and covered by the now-meaningful integration suite (see §3).
   dataset with a `count` column now fails its build with that message rather than at query time. They still parse, so nothing fails loudly; `esql-smoke` compares against the SQL
   equivalent and is what catches them. Land it with D1 as filed. The result table must also read
   `forms` rather than looking for a dot, or a bare `count` column is filed as a dimension.
+
+## v1.15.1 — two `__eq__` methods that never ran (2026-07-31)
+
+- [x] **L2, which closes Stream L.** `GlobalAggregate` and `GroupAggregate` each carried an `__eq__`
+  comparing a chosen subset of their keys. Neither ever ran. Bumped `1.15.0 -> 1.15.1`; the gate is
+  green at **436 tests** (was 428). No behavior change, by construction: the methods were unreachable
+  before and are absent now.
+
+  **Why they could not run.** A TypedDict is not a class with methods. `GlobalAggregate(...)`
+  constructs a plain `dict`, so `type(instance)` is `dict` and Python resolves `==` on `dict`; the
+  function object sits on a type nothing is ever an instance of. They would have raised
+  `AttributeError` if they had, since they used `self.column` attribute access on what is a dict.
+
+  **Why it was worth more than tidiness.** They sat on the comparison the SELECT/HAVING merge in
+  `_build_parsed_query` performs -- `if aggregate not in aggregates[scope]` is a membership test and
+  therefore an equality test -- and that merge is BUG-8's fix from v1.1. So the file declaring the
+  aggregate shapes stated a rule for how aggregates compare, on the path where getting it wrong
+  silently doubles a sum, and the rule was both dead and *wrong*: `GlobalAggregate.__eq__` ignored
+  `group`, while the dict equality that actually runs compares every key.
+
+  **The gap the tamper test found, which is the part worth recording.** The first cut asserted the
+  two dicts unequal and asserted the merge dedups. Reinstating the dead semantics as a *live* merge
+  rule -- dedup on `column` and `function`, ignoring `group` -- **passed all seven tests**. Asserting
+  two values are unequal proves nothing about a comparison that never consults them. The case that
+  bites is two group aggregates in one query (`g1.quant.sum` and `g2.quant.sum`, which scope to
+  different rows), and there was no such query in the file. There is now, and it fails under that
+  tamper. Global and group aggregates cannot collide this way at all, since they live in separate
+  scope lists and are never compared, so `group_specific` is the only place `group` carries weight.
+
+  Covered by `tests/parser/test_aggregate_identity.py` (8 tests), which pins the equality that *runs*
+  rather than the one that was written down. Verified three ways: removing the dedup guard fails 2,
+  the ignore-`group` tamper above fails 1, and **putting the deleted `__eq__` back verbatim passes**,
+  which is the evidence that deleting it is a no-op rather than an assertion that it is.
+
+  **Portfolio-side follow-up: none.** No export, no new name, no `GRAMMAR` key, no behavior.
 
 ## 3. Engine-side prep for the ESQL demo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esql"
-version = "1.15.0"
+version = "1.15.1"
 description = "ESQL is a SQL-based query language for OLAP that computes multiple aggregates across groups without nested subqueries or repeated grouping."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/esql/parser/types.py
+++ b/src/esql/parser/types.py
@@ -12,20 +12,22 @@ class GlobalAggregate(TypedDict):
     aggregate that names no column: it asks how many rows the group holds, and every row holds
     itself. Every other function needs a column, and `column.count` counts that column's *distinct*
     values, so a column named in an aggregate always bears on the answer.
+
+    Two of these are equal when their keys are, which is plain dict equality: a TypedDict *is* a
+    `dict` at runtime, so it carries no identity of its own. That is what the SELECT/HAVING merge in
+    `_build_parsed_query` compares, and `tests/parser/test_aggregate_identity.py` pins it. This class
+    used to define an `__eq__` that ignored `group`; it never ran, because no instance is ever of
+    this type, and it disagreed with the equality that does run.
     """
 
     column: str | None
     function: str
 
-    def __eq__(self, other):
-        return self.column == other.column and self.function == other.function
-
 
 class GroupAggregate(GlobalAggregate):
-    group: str
+    """A `GlobalAggregate` scoped to one OVER group, so `group` is part of its identity."""
 
-    def __eq__(self, other):
-        return self.group == other.group and self.column == other.column and self.function == other.function
+    group: str
 
 
 class AggregatesDict(TypedDict):

--- a/tests/parser/test_aggregate_identity.py
+++ b/tests/parser/test_aggregate_identity.py
@@ -1,0 +1,115 @@
+"""What makes two parsed aggregates the same aggregate.
+
+The SELECT/HAVING merge in `_build_parsed_query` skips an aggregate `already present`, which is a
+list membership test and therefore an equality test. Nothing pinned what that equality *is*, and the
+answer used to be written down twice in disagreement: `GlobalAggregate` and `GroupAggregate` each
+carried an `__eq__` comparing a chosen subset of the keys, while the equality that actually ran was
+plain dict equality over all of them. The methods never ran -- a TypedDict constructs a `dict`, so no
+instance is ever of the class the method is defined on -- so the disagreement was invisible.
+
+These tests pin the equality that runs, so the two cannot drift apart again: deleting the dead
+methods is provably a no-op, and reinstating their semantics fails here rather than silently
+changing which aggregates merge. Getting this wrong is not a crash. An aggregate that merges when it
+should not is computed once and read by two clauses; one that fails to merge is accumulated twice per
+row, which silently doubles a sum, and that is BUG-8 from v1.1.
+"""
+
+from esql.parser.parse import get_parsed_query
+from esql.parser.types import GlobalAggregate, GroupAggregate
+
+
+def test_an_aggregate_is_a_plain_dict_and_compares_as_one():
+    """The premise the merge rests on. A TypedDict has no identity of its own at runtime."""
+    left = GlobalAggregate(column="quant", function="sum")
+    right = GlobalAggregate(column="quant", function="sum")
+
+    assert type(left) is dict
+    assert left == right
+
+
+def test_two_aggregates_differing_only_by_group_are_not_the_same_aggregate():
+    """The case the deleted `__eq__` got wrong, and the reason it mattered.
+
+    `GroupAggregate.__eq__` compared `group`, `column` and `function`; `GlobalAggregate.__eq__`
+    compared only `column` and `function`, so by its rule the two below were equal. They are not:
+    one is a total over every row, the other over one OVER group's rows, and merging them would
+    drop a measure the query asked for.
+    """
+    global_scope = GlobalAggregate(column="quant", function="sum")
+    group_specific = GroupAggregate(group="g1", column="quant", function="sum")
+
+    assert global_scope != group_specific
+    assert group_specific not in [global_scope]
+
+
+def test_two_group_aggregates_differing_only_by_group_are_not_the_same_aggregate():
+    """`g1.quant.sum` and `g2.quant.sum` answer over different rows."""
+    assert GroupAggregate(group="g1", column="quant", function="sum") != GroupAggregate(
+        group="g2", column="quant", function="sum"
+    )
+
+
+def test_the_bare_row_count_is_not_the_same_aggregate_as_a_column_count(sales_test_data):
+    """`count` and `quant.count` differ only in `column`, and answer different questions.
+
+    v1.15.0 made `column` None for the bare form, so this pair is exactly the case where a
+    subset-of-keys equality that skipped `column` would merge two aggregates that must not merge.
+    """
+    row_count = GlobalAggregate(column=None, function="count")
+    distinct_count = GlobalAggregate(column="quant", function="count")
+
+    assert row_count != distinct_count
+
+    parsed = get_parsed_query(sales_test_data, "SELECT cust, count, quant.count")
+    assert parsed["aggregates"]["global_scope"] == [row_count, distinct_count]
+
+
+def test_an_aggregate_named_in_select_and_having_is_merged_to_one(sales_test_data):
+    """BUG-8's regression, at the seam rather than through the accessor.
+
+    A duplicate is accumulated twice per row, which doubles a sum and converts an avg twice.
+    """
+    parsed = get_parsed_query(sales_test_data, "SELECT cust, quant.sum HAVING quant.sum > 25")
+
+    assert parsed["aggregates"]["global_scope"] == [GlobalAggregate(column="quant", function="sum")]
+
+
+def test_a_group_aggregate_in_select_and_having_is_merged_to_one(sales_test_data):
+    """The same merge, in the scope where `group` is part of the identity being compared."""
+    parsed = get_parsed_query(
+        sales_test_data,
+        "SELECT cust, g1.quant.sum OVER g1 SUCH THAT g1.state = 'NY' HAVING g1.quant.sum > 5",
+    )
+
+    assert parsed["aggregates"]["group_specific"] == [GroupAggregate(group="g1", column="quant", function="sum")]
+
+
+def test_two_group_aggregates_differing_only_by_group_both_survive_the_merge(sales_test_data):
+    """The dead `__eq__`'s semantics, caught where they would actually do damage.
+
+    Asserting the two dicts are unequal is not enough, because a merge could compare them on a
+    subset of their keys and never consult that. This is the query where such a merge loses a
+    measure: `g1` and `g2` scope to different rows, so dropping one answers the wrong question
+    under a label the query did ask for. Global and group aggregates cannot collide this way --
+    they live in separate scope lists and are never compared -- so within `group_specific` is the
+    only place `group` has to carry weight.
+    """
+    parsed = get_parsed_query(
+        sales_test_data,
+        "SELECT cust, g1.quant.sum, g2.quant.sum OVER g1, g2 SUCH THAT g1.state = 'NY', g2.state = 'NJ'",
+    )
+
+    assert parsed["aggregates"]["group_specific"] == [
+        GroupAggregate(group="g1", column="quant", function="sum"),
+        GroupAggregate(group="g2", column="quant", function="sum"),
+    ]
+
+
+def test_two_different_aggregates_on_one_column_both_survive_the_merge(sales_test_data):
+    """Equality is over every key, so `function` separates these two."""
+    parsed = get_parsed_query(sales_test_data, "SELECT cust, quant.sum HAVING quant.max > 5")
+
+    assert parsed["aggregates"]["global_scope"] == [
+        GlobalAggregate(column="quant", function="max"),
+        GlobalAggregate(column="quant", function="sum"),
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "esql"
-version = "1.15.0"
+version = "1.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
Closes **Stream L**. No behavior change, by construction — the methods were unreachable before and are absent now.

## What was wrong

`GlobalAggregate` and `GroupAggregate` each carried an `__eq__` comparing a chosen subset of their keys. Neither ever ran.

A TypedDict is not a class with methods. `GlobalAggregate(...)` constructs a plain `dict`, so `type(instance)` is `dict` and Python resolves `==` on `dict`; the function object sits on a type nothing is ever an instance of. They would have raised `AttributeError` if they had run, since they used `self.column` attribute access on what is a dict.

## Why it was worth more than tidiness

They sat on the comparison the SELECT/HAVING merge performs. `if aggregate not in aggregates[scope]` is a membership test and therefore an equality test, and that merge is BUG-8's fix from v1.1 — a duplicate is accumulated twice per row and silently doubles a sum.

So the file declaring the aggregate shapes stated a rule for how aggregates compare, on the path where getting it wrong is silent, and the rule was both dead **and wrong**: `GlobalAggregate.__eq__` ignored `group`, while the dict equality that actually runs compares every key.

Same shape as **K2**'s dead `A or B` defaults — a line that looks like it selects behavior and does not.

## The gap the tamper test found

The first cut of the tests asserted the two dicts unequal and asserted the merge dedups. Reinstating the dead semantics as a *live* merge rule — dedup on `column` and `function`, ignoring `group` — **passed all seven tests**.

Asserting two values are unequal proves nothing about a comparison that never consults them. The case that bites is two group aggregates in one query (`g1.quant.sum` and `g2.quant.sum`, which scope to different rows), and there was no such query in the file. There is now, and it fails under that tamper.

Global and group aggregates cannot collide this way at all — they live in separate scope lists and are never compared — so `group_specific` is the only place `group` carries weight.

## Verification

`tests/parser/test_aggregate_identity.py` (8 tests) pins the equality that *runs* rather than the one that was written down. Verified three ways:

| tamper | result |
|---|---|
| dedup guard removed | fails 2 |
| dedup ignores `group` | fails 1 |
| deleted `__eq__` put back verbatim | **passes** |

The third is the point: it is evidence that deleting the methods is a no-op, rather than an assertion that it is.

## Gate

`make check` green at **436 tests** (was 428). mypy 68 → 66, advisory as before.

## Downstream

None. No export, no new name, no `GRAMMAR` key, no behavior.